### PR TITLE
fix: improve dark mode sidebar highlight readability

### DIFF
--- a/src/styles-v2/design-tokens.css
+++ b/src/styles-v2/design-tokens.css
@@ -221,6 +221,7 @@
   /* V2 Primary - Dark Mode (lighter for visibility) */
   --v2-primary-purple-main: #7c7cff;
   --v2-primary-purple-variant: #8b8bff;
+  --v2-primary-purple-dark: #9b9bff;
   --v2-text-link: #7c7cff;
   --v2-text-link-hover: #9a9aff;
 


### PR DESCRIPTION
## Summary
- Override `--v2-primary-purple-dark` token in dark mode with a lighter purple (`#9b9bff`) so active sidebar menu items and indicators are readable against the dark background

## Test plan
- [x] Verified in browser preview — active sidebar items ("Campus Analytics", "Engagement") are clearly visible in dark mode
- [ ] Check other pages using `--v2-primary-purple-dark` for consistent appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)