### PR TITLE
docs: comprehensive repo documentation + ecosystem context

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -1,31 +1,33 @@
-# Walky — Contexto do Ecossistema (para IA)
+# Walky — Ecosystem Context (for AI)
 
-> **Objetivo deste documento:** servir de **contexto único** para uma IA entender os quatro
-> repositórios que compõem a plataforma Walky. A partir daqui, a IA deve conseguir escrever
-> um **prompt de documentação** e, depois, gerar a documentação de cada repositório de forma
-> consistente. Não é a documentação final — é o mapa que dá à IA a visão de conjunto.
+> **Purpose of this document:** to serve as a **single source of context** for an AI to understand the four
+> repositories that make up the Walky platform. From here, the AI should be able to write a
+> **documentation prompt** and then generate documentation for each repository in a
+> consistent way. This is not the final documentation — it's the map that gives the AI the big picture.
 
 ---
 
-## 0. Visão geral da plataforma
+## 0. Platform overview
 
-**Walky** é uma plataforma de **rede social para campus universitários**. Ajuda estudantes a
-descobrir eventos, encontrar colegas por perto, explorar espaços do campus, trocar mensagens em
-tempo real e organizar encontros espontâneos ("walks"). Atende 10.000+ estudantes em várias
-universidades (ex.: FIU, FAU).
+**Walky** is a **social networking platform for university campuses**. It helps students
+discover events, find peers nearby, explore campus spaces, exchange real-time messages,
+and organize spontaneous meetups ("walks"). It serves 10,000+ students across several
+universities (e.g., FIU, FAU).
 
-A plataforma é composta por **4 repositórios**, todos localizados em `/Volumes/SSDDEV/DEV_PROJETOS/`:
+The platform is made up of **4 repositories**, all located under `/Volumes/SSDDEV/DEV_PROJETOS/`:
 
-| # | Repositório | Pasta | Papel | Público-alvo |
+| # | Repository | Folder | Role | Audience |
 |---|-------------|-------|-------|--------------|
-| 1 | **App móvel (WOC)** | `walkyApp` | App iOS/Android que o estudante usa | Estudantes |
-| 2 | **Backend** | `walky-backend` | API REST + WebSockets, banco de dados | (serve todos) |
-| 3 | **Admin** | `walky-admin` | Painel administrativo (CoreUI) | Admins de campus/escola, moderadores |
-| 4 | **HQ** | `walky-hq` | Painel super-admin/analytics (shadcn) | Super-admins Walky (interno) |
+| 1 | **Mobile app (WOC)** | `walkyApp` | iOS/Android app used by students | Students |
+| 2 | **Backend** | `walky-backend` | REST API + WebSockets, database | (serves everyone) |
+| 3 | **Admin** | `walky-admin` | Admin panel (CoreUI) | Campus/school admins, moderators |
+| 4 | **HQ** | `walky-hq` | Super-admin/analytics panel (shadcn) | Walky super-admins (internal) |
 
-**Fluxo de dependência:** o **App**, o **Admin** e o **HQ** são todos clientes do **Backend**.
-Admin e HQ geram seus tipos TypeScript a partir do **Swagger/OpenAPI do backend**
-(`../walky-backend/swagger.json`). O App usa **Orval** para gerar hooks React Query do mesmo Swagger.
+**Dependency flow:** the **App**, the **Admin**, and the **HQ** are all clients of the **Backend**.
+Their type-generation strategies differ: **walky-admin** generates its TypeScript types from the
+**backend Swagger/OpenAPI** (`../walky-backend/swagger.json`) using `swagger-typescript-api`, and
+the **App** uses **Orval** to generate React Query hooks from the same Swagger. **walky-hq does NOT**
+generate types from Swagger — its types are **hand-written** in `src/types/`.
 
 ```
                     ┌──────────────────┐
@@ -41,296 +43,301 @@ Admin e HQ geram seus tipos TypeScript a partir do **Swagger/OpenAPI do backend*
       └────────────┘  └──────────────┘  └─────────────┘
 ```
 
-**Convenção de geração de tipos (comum aos 3 clientes):** todos consomem o contrato OpenAPI do
-backend. Mudança de contrato no backend → regenerar tipos/clients nos 3 frontends.
+**Type-generation convention:** the App and Admin consume the backend's OpenAPI contract to
+generate their clients/types (Orval for the App, `swagger-typescript-api` for the Admin), while HQ
+keeps its types hand-written. A backend contract change → regenerate the App and Admin
+types/clients (and manually update HQ's hand-written types where affected).
 
 ---
 
-## 1. walkyApp — App móvel (WOC)
+## 1. walkyApp — Mobile app (WOC)
 
-**Propósito:** app móvel voltado ao estudante. Conexão entre pares, compartilhamento de
-localização em tempo real, mensagens, eventos e descoberta via mapa. Versão atual **3.5.2**.
-Repositório privado.
+**Purpose:** student-facing mobile app. Peer-to-peer connection, real-time
+location sharing, messaging, events, and map-based discovery. Current version **3.5.2**.
+Private repository.
 
 ### Stack
 - **React Native** 0.81.4 · **React** 19.1 · **TypeScript** 5.9 · **Expo** 54 (dev client)
-- **Gerenciador de pacotes:** Bun 1.2.4
-- **Estado:** Zustand 4.5 (`useGlobalStore`) + React Query 5.80 (server state)
-- **API client:** Orval 7.11 (gera hooks React Query a partir do Swagger) + Axios
-- **Navegação:** Expo Router 6 (file-based) + React Navigation 7
-- **UI/animação:** Reanimated 4, Gesture Handler, Gorhom Bottom Sheet, Unistyles 3, Lottie
-- **Tempo real:** socket.io-client 4.8 (WebSocket + polling fallback p/ WiFi restritivo do campus)
-- **Mapas/localização:** react-native-maps, Turf.js, Expo Location (com background tracking)
-- **Monitoramento/analytics:** Sentry, Firebase Analytics, Mixpanel, PostHog, Pendo
+- **Package manager:** Bun 1.2.4
+- **State:** Zustand 4.5 (`useGlobalStore`) + React Query 5.80 (server state)
+- **API client:** Orval 7.11 (generates React Query hooks from Swagger) + Axios
+- **Navigation:** Expo Router 6 (file-based) + React Navigation 7
+- **UI/animation:** Reanimated 4, Gesture Handler, Gorhom Bottom Sheet, Unistyles 3, Lottie
+- **Real-time:** socket.io-client 4.8 (WebSocket + polling fallback for restrictive campus WiFi)
+- **Maps/location:** react-native-maps, Turf.js, Expo Location (with background tracking)
+- **Monitoring/analytics:** Sentry, Firebase Analytics, Mixpanel, PostHog, Pendo
 - **Storage:** AsyncStorage, MMKV, Expo FileSystem
 
-### Estrutura (`src/`)
-- `app/` — rotas file-based do Expo Router: `(public)` (auth), `(main-v3)` (tabs autenticadas),
-  `(global-v3)` (modais), `(bottom-sheet)`
-- `features/` — módulos por feature: `auth`, `home`, `events-v3`, `chat-v3`, `explore`, `map`,
+### Structure (`src/`)
+- `app/` — Expo Router file-based routes: `(public)` (auth), `(main-v3)` (authenticated tabs),
+  `(global-v3)` (modals), `(bottom-sheet)`
+- `features/` — feature modules: `auth`, `home`, `events-v3`, `chat-v3`, `explore`, `map`,
   `peers`, `profile`, `spaces`, `ideas-v3`, `report`, `upgrades`, `sa-onboarding`, `bottomTabBar`
-- `components/common/` — 46+ componentes reutilizáveis
-- `services/` — camada de integração: `API/` (Axios), `analytics/`, `notifications/`, `location/`,
+- `components/common/` — 46+ reusable components
+- `services/` — integration layer: `API/` (Axios), `analytics/`, `notifications/`, `location/`,
   `featureFlags/`, `deeplink/`, `prefetch/`, `logging/`
-- `api/generated/` — cliente gerado por Orval (`walky.ts`) · `api/mutator/` — Axios custom
-- `hooks/` — hooks de socket por feature (`useEventSocket`, `useInviteSocket`, etc.)
+- `api/generated/` — Orval-generated client (`walky.ts`) · `api/mutator/` — custom Axios
+- `hooks/` — per-feature socket hooks (`useEventSocket`, `useInviteSocket`, etc.)
 - `store/global/`, `query/`, `theme/`, `styles/unistyles.ts`, `utils/`
 
-### Features principais
-`auth` (login/onboarding), `home` (feed/descoberta), `events-v3` (criar/RSVP/chat de evento),
-`chat-v3` (DM + chat de evento em tempo real), `explore`+`map` (descoberta por mapa),
-`peers` (perfis/conexões), `profile`, `spaces` (comunidades), `ideas-v3`, `report` (moderação).
+### Core features
+`auth` (login/onboarding), `home` (feed/discovery), `events-v3` (create/RSVP/event chat),
+`chat-v3` (DM + real-time event chat), `explore`+`map` (map-based discovery),
+`peers` (profiles/connections), `profile`, `spaces` (communities), `ideas-v3`, `report` (moderation).
 
-### Integração com backend
-- **HTTP:** Axios em `src/services/API/`, base via env `BASE_URL`, Bearer token via `AuthService`,
-  refresh automático no 401, checagem de conectividade (netinfo) antes de requisitar.
-- **Socket:** `SocketProvider` em `src/utils/sockets/`, auth por token no handshake,
-  WebSocket + long-polling, reconnect tunado p/ mobile.
-- **Orval:** config em `orval.config.ts`, gera hooks em `src/api/generated/walky.ts`.
+### Backend integration
+- **HTTP:** Axios in `src/services/API/`, base URL from env `BASE_URL`, Bearer token via `AuthService`,
+  automatic refresh on 401, connectivity check (netinfo) before requesting.
+- **Socket:** `SocketProvider` in `src/utils/sockets/`, token-based auth on handshake,
+  WebSocket + long-polling, reconnect tuned for mobile.
+- **Orval:** config in `orval.config.ts`, generates hooks in `src/api/generated/walky.ts`.
   Scripts: `api:generate`, `api:generate:watch`, `api:fetch-swagger`.
 
 ### Env vars
 `APP_ID`, `DISPLAY_NAME`, `BASE_URL`, `SOCKET_URL`, `GOOGLE_MAPS_API_KEY`, `SENTRY_DSN`,
 `MIXPANEL_TOKEN`, `POSTHOG_API_KEY`, `PENDO_API_KEY`, `USE_BACKGROUND_LOCATION`.
-Arquivos: `.env`, `.env.staging`, `.env.production`, `.env.e2e`.
+Files: `.env`, `.env.staging`, `.env.production`, `.env.e2e`.
 
 ### Build/run
 - Scripts (Bun): `bun start`, `bun ios`, `bun android`, `bun type-check`, `bun lint`, `bun test`,
   `bun test:e2e`, `bun api:generate`.
-- **EAS** (`eas.json`): perfis `development`, `development-device`, `preview`, `staging`,
+- **EAS** (`eas.json`): profiles `development`, `development-device`, `preview`, `staging`,
   `production`, `e2e-test`. iOS→TestFlight, Android→Firebase App Distribution/Google Play.
-- **Testes:** Jest (unit, 40+ mocks) + Maestro (E2E em YAML, `.maestro/`).
+- **Tests:** Jest (unit, 40+ mocks) + Maestro (E2E in YAML, `.maestro/`).
 
-### Convenção local (deste ambiente)
-- O simulador **sempre** aponta para o backend local (`walky-backend`), nunca staging/prod.
-- Backend local roda em `PORT=8080`; Metro usa 8081. `.env`: `BASE_URL=http://localhost:8080`,
-  `SOCKET_URL=ws://localhost:8080`. Após alterar `.env`, reiniciar Metro com
+### Local convention (this environment)
+- The simulator **always** points to the local backend (`walky-backend`), never staging/prod.
+- The local backend runs on `PORT=8080`; Metro uses 8081. `.env`: `BASE_URL=http://localhost:8080`,
+  `SOCKET_URL=ws://localhost:8080`. After changing `.env`, restart Metro with
   `npx expo start --dev-client --clear`.
 
 ---
 
-## 2. walky-backend — API REST + WebSockets
+## 2. walky-backend — REST API + WebSockets
 
-**Propósito:** API REST central da plataforma (serve app, admin e HQ). Node.js/Express/TypeScript
-com MongoDB, Redis e Socket.io. Deploy em **GCP Cloud Run**. Equipe pequena (2–3 devs), foco em
-velocidade e tempo real.
+**Purpose:** the platform's central REST API (serves the app, admin, and HQ). Node.js/Express/TypeScript
+with MongoDB, Redis, and Socket.io. Deployed on **GCP Cloud Run**. Small team (2–3 devs), focused on
+speed and real-time features.
 
 ### Stack
 - **TypeScript** (strict) · **Node 20+** · **Express** · **MongoDB 4.12+ / Mongoose 7.2** ·
-  **Redis** (location sync, tempo real) · **Socket.io 4.7**
-- **GCP:** Cloud Run (hosting), Cloud Build (CI/CD), Secret Manager, Cloud Storage (imagens),
-  Cloud Logging, Cloud Vision (moderação de imagem), Cloud Tasks
-- **Integrações:** Sentry, Firebase FCM (push), Expo Server SDK (push V2), SendGrid (email),
+  **Redis** (location sync, real-time) · **Socket.io 4.7**
+- **GCP:** Cloud Run (hosting), Cloud Build (CI/CD), Secret Manager, Cloud Storage (images),
+  Cloud Logging, Cloud Vision (image moderation), Cloud Tasks
+- **Integrations:** Sentry, Firebase FCM (push), Expo Server SDK (push V2), SendGrid (email),
   Twilio (SMS/OTP), Google Analytics 4, Google Places API, Replicate (upscale), Sharp, Rebrandly
-- **Auth:** JWT + SAML 2.0 (SSO universitário, ex.: FAU)
-- **Testes:** Jest 30 + ts-jest + MongoDB Memory Server
+- **Auth:** JWT + SAML 2.0 (university SSO, e.g., FAU)
+- **Tests:** Jest 30 + ts-jest + MongoDB Memory Server
 
-### Estrutura (`src/`)
-- `index.ts` (entry + socket init), `config.ts`, `config/` (SAML, universidades, GCS, certs)
-- `routes/` (54 arquivos) — inclui `dualRouter.ts` (roteia `/api/*` **e** paths legados na raiz)
-- `controllers/` (70+), `services/` (61), `model/` (52 schemas Mongoose)
-- `middleware/` (11 — auth, rate limit de login, bad words, permissões)
-- `jobs/` (14 — cleanup de eventos, rollover de recorrentes, lembretes, agregação de analytics,
-  alertas, engagement scores)
-- `sockets/` — `walk.socket`, `chat.socket`, `explore.socket` + middleware de auth
-- `validators/`, `repositories/`, `migrations/` (98+ scripts), `scripts/` (54, seed/utilitários),
+### Structure (`src/`)
+- `index.ts` (entry + socket init), `config.ts`, `config/` (SAML, universities, GCS, certs)
+- `routes/` (54 files) — includes `dualRouter.ts` (routes `/api/*` **and** legacy paths at the root)
+- `controllers/` (70+), `services/` (61), `model/` (52 Mongoose schemas)
+- `middleware/` (11 — auth, login rate limiting, bad words, permissions)
+- `jobs/` (14 — event cleanup, recurring rollover, reminders, analytics aggregation,
+  alerts, engagement scores)
+- `sockets/` — `walk.socket`, `chat.socket`, `explore.socket` + auth middleware
+- `validators/`, `repositories/`, `migrations/` (98+ scripts), `scripts/` (54, seed/utilities),
   `templates/emails/`
 
-### Domínios principais
-Auth/RBAC · Users/Profiles · **Events** (core) · **Walks** (encontros espontâneos em tempo real) ·
-Chat/Messaging · Spaces/Places (locais do campus + Google Places) · Ideas · Interests/Communities ·
-Admin/Moderação · Notificações · Analytics/Métricas · Location/Discovery.
+### Core domains
+Auth/RBAC · Users/Profiles · **Events** (core) · **Walks** (spontaneous real-time meetups) ·
+Chat/Messaging · Spaces/Places (campus locations + Google Places) · Ideas · Interests/Communities ·
+Admin/Moderation · Notifications · Analytics/Metrics · Location/Discovery.
 
-### Banco de dados
-- **MongoDB Atlas.** Ambientes: **prod** (cluster `prod`), **staging**, dev local.
-  > ⚠️ Nota de contexto do time: o DB de produção se chama **`prod`** (não `walky`/`staging`).
-- **52 coleções** (models). Core: `users`, `events`, `walks`, `chat`, `spaces`, `ideas`,
-  `interests`. Relacionamentos: `eventInvites`, `peerRequests`, `walkInvites`, `spaceMember`.
+### Database
+- **MongoDB Atlas.** Environments: **prod** (cluster `prod`), **staging**, local dev.
+  > ⚠️ Team context note: the production DB is named **`prod`** (not `walky`/`staging`).
+- **52 collections** (models). Core: `users`, `events`, `walks`, `chat`, `spaces`, `ideas`,
+  `interests`. Relationships: `eventInvites`, `peerRequests`, `walkInvites`, `spaceMember`.
   Admin: `reports`, `roles`, `permissions`, `auditLogs`, `adminMessages`. Analytics:
   `campusMetricsCache`, `campusAlerts`, `userActivityLog`, `profileView`. Places: `place`,
   `placeType`, `popularPlace`, `campus`, `school`, `areaOfStudy`.
 
 ### Auth
 - **JWT:** access 24h + refresh 7d. Payload `{ sub, email, role, tokenVersion, iat }`,
-  issuer `walky-app`, audience `walky-users`. `authMiddleware.ts` valida. Segredo em `JWT_SECRET`.
-  Revogação via incremento de `tokenVersion`.
-- **SAML 2.0:** SSO universitário (`saml-config-v2.ts`, certs em `config/certificates/`).
-- **RBAC:** roles Student/Faculty/Admin/Sales via IDs em env (`ADMIN_ROLE`, `STUDENT_ROLE`, etc.).
+  issuer `walky-app`, audience `walky-users`. `authMiddleware.ts` validates it. Secret in `JWT_SECRET`.
+  Revocation via incrementing `tokenVersion`.
+- **SAML 2.0:** university SSO (`saml-config-v2.ts`, certs in `config/certificates/`).
+- **RBAC:** Student/Faculty/Admin/Sales roles via IDs in env (`ADMIN_ROLE`, `STUDENT_ROLE`, etc.).
 
-### Tempo real (Socket.io)
-Namespaces separados: **walk** (convites/localização ao vivo), **chat** (DM + grupo),
-**explore** (feed de descoberta). Rate limit 15 conexões/min por IP (máx 5). Auth JWT no handshake.
+### Real-time (Socket.io)
+Separate namespaces: **walk** (invites/live location), **chat** (DM + group),
+**explore** (discovery feed). Rate limit 15 connections/min per IP (max 5). JWT auth on handshake.
 
-### Run local
-- Node 20+, MongoDB, Redis, `.env` (pedir ao time). `yarn install` → `yarn dev` → **porta 8081**
-  (ou `PORT`). No contexto deste ambiente, roda-se em **8080** para o simulador do app.
+### Local run
+- Node 20+, MongoDB, Redis, `.env` (ask the team). `yarn install` → `yarn dev` → **port 8081**
+  (or `PORT`). In this environment, it runs on **8080** for the app simulator.
 - Scripts: `yarn dev|staging|prod|build|test|test:watch|lint|format|seed`.
-- **Swagger:** local `http://localhost:8081/api-docs/`, staging/prod idem sob os domínios.
+- **Swagger:** local `http://localhost:8081/api-docs/`; staging/prod the same under their domains.
 
-### Env vars (principais)
+### Env vars (main ones)
 `PORT`, `NODE_ENV`, `PROJECT_ID`, `MONGO_URI`, `REDIS_URL`, `JWT_SECRET`,
 `FIREBASE_PROJECT_ID/PRIVATE_KEY/CLIENT_EMAIL`, `TWILIO_*`, `SENDGRID_API_KEY`,
-`AWS_REGION/ACCESS_KEY_ID/SECRET_ACCESS_KEY/S3_BUCKET` (legado), `EXPO_ACCESS_TOKEN`,
+`AWS_REGION/ACCESS_KEY_ID/SECRET_ACCESS_KEY/S3_BUCKET` (legacy), `EXPO_ACCESS_TOKEN`,
 `ADMIN_ROLE/STUDENT_ROLE/FACULTY_ROLE/SALES_ROLE`, `REBRANDLY_API_KEY`.
 
-### Ambientes
-- Produção: `https://api.walkyapp.com` (branch `main`)
+### Environments
+- Production: `https://api.walkyapp.com` (branch `main`)
 - Staging: `https://staging.walkyapp.com` (branch `staging`)
 - Dev: `http://localhost:8081`
 
 ---
 
-## 3. walky-admin — Painel administrativo (CoreUI)
+## 3. walky-admin — Admin panel (CoreUI)
 
-**Propósito:** painel para **admins de campus, admins de escola, moderadores e super-admins**
-gerenciarem estudantes, eventos, spaces, ideas, moderação e configurações de campus.
+**Purpose:** a panel for **campus admins, school admins, moderators, and super-admins** to
+manage students, events, spaces, ideas, moderation, and campus configuration.
 
 ### Stack
 - **TypeScript** 5.8 · **React** 19.1 · **React Router** v7.6 · **Vite** 7 · **Node** ≥20
-- **UI:** **CoreUI 5.7** + React Bootstrap 2.10 (framework de admin tradicional)
-- **Dados:** Axios 1.10 + React Query 5.82; tipos gerados via Swagger TypeScript API
-- **Estado:** React Context + React Query
-- **Viz:** Recharts 3.4 + Three.js (visualizações 3D no "Playground")
-- **Estilo:** CSS + Sass, design tokens via CSS variables (dual: CoreUI + tokens V2)
-- **Testes:** Vitest 4 + React Testing Library + MSW; checagem de `data-testid` e a11y
+- **UI:** **CoreUI 5.7** + React Bootstrap 2.10 (traditional admin framework)
+- **Data:** Axios 1.10 + React Query 5.82; types generated from Swagger via `swagger-typescript-api`
+- **State:** React Context + React Query
+- **Viz:** Recharts 3.4 + Three.js (3D visualizations in the "Playground")
+- **Styling:** CSS + Sass, design tokens via CSS variables (dual: CoreUI + V2 tokens)
+- **Tests:** Vitest 4 + React Testing Library + MSW; `data-testid` and a11y checks
 
-### Estrutura (`src/`)
-`API/` (cliente Swagger gerado) · `components-v2/` (53 componentes) · `contexts/` (Auth, School,
+### Structure (`src/`)
+`API/` (generated Swagger client) · `components-v2/` (53 components) · `contexts/` (Auth, School,
 Campus, Theme) · `hooks/` (`useAuth`, `usePermissions`, `useTheme`) · `layout-v2/` (Sidebar+Topbar) ·
-`lib/` (logger, queryClient, matriz de permissões) · `pages-v2/` (telas) · `routes/v2Routes.tsx`
+`lib/` (logger, queryClient, permissions matrix) · `pages-v2/` (screens) · `routes/v2Routes.tsx`
 (lazy loading) · `services/` (userService, campusService, etc.) · `styles-v2/` (tokens) · `test/`.
 
-### Telas principais
+### Main screens
 - **Dashboards (6):** Engagement, Popular Features, User Interactions, Community, Student Safety,
   Student Behavior
-- **Campus/Estudantes (4 listas):** Active, Banned, Deactivated, Disengaged
+- **Campus/Students (4 lists):** Active, Banned, Deactivated, Disengaged
 - **Events:** Manager, Insights, Check-In Analytics
 - **Spaces:** Manager, Insights · **Ideas:** Manager, Insights
-- **Moderação:** Report Safety, Report History
-- **Administração (super/school admin):** Campuses (geofences, ambassadors), Ambassadors,
+- **Moderation:** Report Safety, Report History
+- **Administration (super/school admin):** Campuses (geofences, ambassadors), Ambassadors,
   Role Management, Administrator Settings
-- **Playground:** 14 visualizações experimentais de dados
-- **Auth:** Login (+2FA opcional), recuperação de senha, troca forçada de senha
+- **Playground:** 14 experimental data visualizations
+- **Auth:** Login (+ optional 2FA), password recovery, forced password change
 
-### Integração com backend
-- Axios com interceptors. Base via `VITE_API_BASE_URL`
+### Backend integration
+- Axios with interceptors. Base URL from `VITE_API_BASE_URL`
   (prod `https://api.walkyapp.com/api`, local `http://localhost:8080|8081/api`).
-- Bearer token em localStorage + proteção CSRF (token de cookie em requests não-GET).
-- 401→logout/redirect login; 403 com `ACCOUNT_DEACTIVATED`→modal; retry (máx 3, pula 4xx exceto 408).
-- Camada de services + React Query (stale 5min, cache 10min).
+- Bearer token in localStorage + CSRF protection (cookie token on non-GET requests).
+- 401→logout/redirect to login; 403 with `ACCOUNT_DEACTIVATED`→modal; retry (max 3, skips 4xx except 408).
+- Services layer + React Query (stale 5min, cache 10min).
 
 ### Auth
-Token+user em localStorage. `useAuth()` reativo. **RBAC** com roles
-`super_admin`/`school_admin`/`campus_admin`/`moderator`/`walky_internal`; matriz em
-`src/lib/permissions.ts`; `<PermissionGuard>` e `<AuthGuard>` protegem rotas. Sync entre abas via
+Token+user in localStorage. `useAuth()` is reactive. **RBAC** with roles
+`super_admin`/`school_admin`/`campus_admin`/`moderator`/`walky_internal`; matrix in
+`src/lib/permissions.ts`; `<PermissionGuard>` and `<AuthGuard>` protect routes. Cross-tab sync via
 storage events.
 
 ### Build/run
-`npm run dev` (porta 5173), `build`, `preview`, `type-check`, `lint`, `test`, `test:coverage`,
-`check:testids`, `check:a11y`, `check:all`, `generate:api` (requer `../walky-backend/swagger.json`),
-`generate:icons`, `generate:images`. Deploy Vercel.
-Env: `VITE_API_BASE_URL`, `VITE_APP_NAME`, `VITE_ENV`, (opc.) `VITE_GOOGLE_MAPS_API_KEY`,
+`npm run dev` (port 5173), `build`, `preview`, `type-check`, `lint`, `test`, `test:coverage`,
+`check:testids`, `check:a11y`, `check:all`, `generate:api` (requires `../walky-backend/swagger.json`),
+`generate:icons`, `generate:images`. Deployed on Vercel.
+Env: `VITE_API_BASE_URL`, `VITE_APP_NAME`, `VITE_ENV`, (optional) `VITE_GOOGLE_MAPS_API_KEY`,
 `VITE_SENTRY_DSN`.
+The local `.env` is git-ignored; only the committed template (`.env.example`/`.env.template`) is tracked.
 
 ---
 
-## 4. walky-hq — Painel super-admin / Analytics (shadcn)
+## 4. walky-hq — Super-admin / Analytics panel (shadcn)
 
-**Propósito:** dashboard de **HQ / super-admin** para o time interno Walky. Administração global da
-plataforma, analytics avançado, moderação e configuração de entidades core (usuários, escolas,
-campi, interesses, spaces, roles). É o sistema mais novo e sofisticado.
+**Purpose:** an **HQ / super-admin** dashboard for the internal Walky team. Global platform
+administration, advanced analytics, moderation, and configuration of core entities (users, schools,
+campuses, interests, spaces, roles). It's the newest and most sophisticated system.
 
 ### Stack
 - **React** 19 · **TypeScript** 5.7 (strict) · **Vite** 6 · **React Router** 6.22 · **Node** 18+ · Yarn
-- **UI:** **shadcn/ui** (Radix) + **Tailwind CSS** 3.3 + Lucide + Sonner (moderno, utility-first)
-- **Estado:** Zustand 5 (auth, persistido em localStorage) + React Query 5.67 + Context (school/campus)
-- **Dados:** Axios 1.8 (interceptors + refresh) + React Hook Form 7.54 + Zod 3.24
+- **UI:** **shadcn/ui** (Radix) + **Tailwind CSS** 3.3 + Lucide + Sonner (modern, utility-first)
+- **State:** Zustand 5 (auth, persisted in localStorage) + React Query 5.67 + Context (school/campus)
+- **Data:** Axios 1.8 (interceptors + refresh) + React Hook Form 7.54 + Zod 3.24
 - **Viz:** Recharts 3.3 · @dnd-kit (drag-and-drop) · Google Maps · Google Analytics Data API · Firebase 12
 
-### Estrutura (`src/`)
+### Structure (`src/`)
 `api/` (`client.ts` + 25+ services) · `components/` (`ui/` shadcn, `common/`, `analytics/`,
 `layout/`, `filters/`) · `pages/` (35+) · `router/` (`ProtectedRoute.tsx`) · `store/authStore.ts` ·
-`contexts/` (School, Campus) · `hooks/` · `types/` (100+ interfaces) · `utils/` · `lib/` (firebase, cn).
+`contexts/` (School, Campus) · `hooks/` · `types/` (hand-written; ~43 interfaces in `src/types/index.ts`) · `utils/` · `lib/` (firebase, cn).
 
-### Telas principais (35+ rotas)
+### Main screens (35+ routes)
 Dashboard (overview) · Engagement · Users · Walks · Events · Schools · Places · Popular Places ·
-Interests · Interest Groups · Place Types · Surprise Rolls · Ideas · Spaces (+categorias) ·
+Interests · Interest Groups · Place Types · Surprise Rolls · Ideas · Spaces (+categories) ·
 Roles (RBAC) · Reports · Banned Users · Areas of Study · Report Reasons · Deletion Requests ·
-Audit Logs · User Activity · Locked Users · Jobs (monitoramento de background jobs) · Messages · Profile.
-**Analytics avançado:** session, messaging, profile views, engagement, lifecycle, social graph,
+Audit Logs · User Activity · Locked Users · Jobs (background job monitoring) · Messages · Profile.
+**Advanced analytics:** session, messaging, profile views, engagement, lifecycle, social graph,
 referrals, safety.
 
-### Integração com backend
-- `src/api/client.ts` (Axios). Base via `VITE_BASE_URL`
+### Backend integration
+- `src/api/client.ts` (Axios). Base URL from `VITE_BASE_URL`
   (dev `http://localhost:8080`, staging `https://staging.walkyapp.com`, prod `https://api.walkyapp.com`).
-- Interceptors: injeta Bearer token; no 401 faz refresh e re-fila requests; falha→logout/redirect.
-- Tokens em localStorage (`token`, `refresh_token`, `auth-storage`). 25+ services em `api/services/`.
+- Interceptors: inject Bearer token; on 401, refresh and re-queue requests; on failure→logout/redirect.
+- Tokens in localStorage (`token`, `refresh_token`, `auth-storage`). 25+ services in `api/services/`.
 
 ### Auth
-JWT com rotação de refresh token. Zustand `authStore` persiste `token/refreshToken/user/isAuthenticated`.
-`ProtectedRoute` checa `isAuthenticated`. Credencial de teste conhecida: `gal@walkyapp.com`.
+JWT with refresh-token rotation. Zustand `authStore` persists `token/refreshToken/user/isAuthenticated`.
+`ProtectedRoute` checks `isAuthenticated`. Known test credential: `gal@walkyapp.com`.
 
 ### Build/run
-`yarn dev` (porta 5173), `build`, `lint`, `preview`. Deploy Vercel (`vercel.json`, saída `dist/`).
-Env: `VITE_BASE_URL` (obrigatório), `VITE_GA_PROPERTY_ID` (opcional).
+`yarn dev` (port 5173), `build`, `lint`, `preview`. Deployed on Vercel (`vercel.json`, output `dist/`).
+Env: `VITE_BASE_URL` (required), `VITE_GA_PROPERTY_ID` (optional).
+The local `.env` is git-ignored; only the committed template (`.env.example`/`.env.template`) is tracked.
 
 ---
 
-## 5. Admin vs HQ — como diferem
+## 5. Admin vs HQ — how they differ
 
-| Aspecto | walky-admin | walky-hq |
+| Aspect | walky-admin | walky-hq |
 |--------|-------------|----------|
 | UI | CoreUI 5 + Bootstrap | shadcn/ui + Tailwind |
 | Build | Vite 7 | Vite 6 |
-| Estado | Context + React Query | Zustand + React Query |
-| Público | Admins de campus/escola, moderadores | Super-admins internos Walky |
-| Ênfase | Gestão operacional por campus, moderação | Analytics global avançado, config de entidades core |
-| Maturidade | Sistema com CoreUI, orientado a operação | Sistema mais novo/sofisticado |
+| State | Context + React Query | Zustand + React Query |
+| Audience | Campus/school admins, moderators | Internal Walky super-admins |
+| Focus | Per-campus operational management, moderation | Advanced global analytics, core-entity config |
+| Maturity | CoreUI-based, operations-oriented system | Newer/more sophisticated system |
 
-Há **sobreposição funcional** (ambos têm users, events, spaces, ideas, reports, roles, campus).
-A distinção é de **escopo e público**: Admin é operação por campus/escola; HQ é super-admin/analytics global.
-
----
-
-## 6. Fatos transversais úteis para a IA
-
-- **Contrato único:** os 3 frontends derivam tipos do **Swagger do backend**. Documentar o backend
-  primeiro dá base para os clients.
-- **Auth consistente:** JWT (access + refresh) em toda a stack; RBAC por roles; backend também
-  suporta SAML SSO universitário.
-- **Tempo real:** Socket.io no backend (namespaces walk/chat/explore) consumido pelo app.
-- **Multi-tenant por campus/escola:** entidades `school`/`campus` permeiam todos os repos;
-  contexts de School/Campus existem tanto no Admin quanto no HQ.
-- **Domínios de negócio compartilhados** (vocabulário comum a documentar uma vez): Users, Events,
-  Walks, Chat, Spaces/Places, Ideas, Interests, Reports/Moderação, Analytics, Campus/School, Roles.
-- **Deploy:** backend em GCP Cloud Run; Admin e HQ em Vercel; App via EAS (TestFlight / Firebase / Play).
-- **Ambientes backend:** prod (`api.walkyapp.com`), staging (`staging.walkyapp.com`), local (8081).
+There is **functional overlap** (both have users, events, spaces, ideas, reports, roles, campus).
+The distinction is one of **scope and audience**: Admin is per-campus/school operations; HQ is super-admin/global analytics.
 
 ---
 
-## 7. Localização dos repositórios
+## 6. Cross-cutting facts useful for the AI
+
+- **Contract source:** the App and Admin derive their types from the **backend Swagger** (App via
+  Orval, Admin via `swagger-typescript-api`), while HQ's types are hand-written. Documenting the
+  backend first gives a foundation for the clients.
+- **Consistent auth:** JWT (access + refresh) across the whole stack; role-based RBAC; the backend also
+  supports university SAML SSO.
+- **Real-time:** Socket.io on the backend (walk/chat/explore namespaces), consumed by the app.
+- **Multi-tenant by campus/school:** `school`/`campus` entities run through every repo;
+  School/Campus contexts exist in both Admin and HQ.
+- **Shared business domains** (common vocabulary to document once): Users, Events,
+  Walks, Chat, Spaces/Places, Ideas, Interests, Reports/Moderation, Analytics, Campus/School, Roles.
+- **Deploy:** backend on GCP Cloud Run; Admin and HQ on Vercel; App via EAS (TestFlight / Firebase / Play).
+- **Backend environments:** prod (`api.walkyapp.com`), staging (`staging.walkyapp.com`), local (8081).
+
+---
+
+## 7. Repository locations
 
 ```
 /Volumes/SSDDEV/DEV_PROJETOS/
-├── walkyApp/        # App móvel (WOC)  — React Native / Expo
-├── walky-backend/   # API + WS         — Node / Express / Mongo / Redis
-├── walky-admin/     # Admin            — React / CoreUI / Vite
-└── walky-hq/        # HQ super-admin   — React / shadcn / Vite
+├── walkyApp/        # Mobile app (WOC)  — React Native / Expo
+├── walky-backend/   # API + WS          — Node / Express / Mongo / Redis
+├── walky-admin/     # Admin             — React / CoreUI / Vite
+└── walky-hq/        # HQ super-admin    — React / shadcn / Vite
 ```
 
-Cada repositório tem seu próprio `README.md`; `walky-hq` e `walky-admin` também têm um
-`claude.md`/`CLAUDE.md` com notas de desenvolvimento.
+Each repository has its own `README.md`; `walky-hq` and `walky-admin` also have a
+`claude.md`/`CLAUDE.md` with development notes.
 
 ---
 
-## 8. Como a IA deve usar este documento
+## 8. How the AI should use this document
 
-1. **Entender o conjunto** antes de documentar qualquer repo isolado (dependências e contrato comum).
-2. **Escrever um prompt de documentação** que:
-   - documente o **backend primeiro** (é a fonte do contrato/tipos e dos domínios de negócio);
-   - reutilize o **vocabulário de domínio** da seção 6 para manter consistência entre repos;
-   - para cada frontend, cubra: propósito/público, stack, estrutura de pastas, telas/features,
-     integração com backend (base URL/env/auth), build/run e deploy;
-   - destaque **diferenças Admin vs HQ** para não duplicar/confundir.
-3. **Manter um glossário único** dos domínios (Events, Walks, Spaces, Ideas, Campus/School, Roles…)
-   referenciado pelos quatro repositórios.
+1. **Understand the whole** before documenting any repo in isolation (dependencies and shared contract).
+2. **Write a documentation prompt** that:
+   - documents the **backend first** (it's the source of the contract/types and business domains);
+   - reuses the **domain vocabulary** from section 6 to keep repos consistent;
+   - for each frontend, covers: purpose/audience, stack, folder structure, screens/features,
+     backend integration (base URL/env/auth), build/run, and deploy;
+   - highlights the **Admin vs HQ differences** to avoid duplication/confusion.
+3. **Maintain a single glossary** of the domains (Events, Walks, Spaces, Ideas, Campus/School, Roles…)
+   referenced across all four repositories.

--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -1,0 +1,336 @@
+# Walky — Contexto do Ecossistema (para IA)
+
+> **Objetivo deste documento:** servir de **contexto único** para uma IA entender os quatro
+> repositórios que compõem a plataforma Walky. A partir daqui, a IA deve conseguir escrever
+> um **prompt de documentação** e, depois, gerar a documentação de cada repositório de forma
+> consistente. Não é a documentação final — é o mapa que dá à IA a visão de conjunto.
+
+---
+
+## 0. Visão geral da plataforma
+
+**Walky** é uma plataforma de **rede social para campus universitários**. Ajuda estudantes a
+descobrir eventos, encontrar colegas por perto, explorar espaços do campus, trocar mensagens em
+tempo real e organizar encontros espontâneos ("walks"). Atende 10.000+ estudantes em várias
+universidades (ex.: FIU, FAU).
+
+A plataforma é composta por **4 repositórios**, todos localizados em `/Volumes/SSDDEV/DEV_PROJETOS/`:
+
+| # | Repositório | Pasta | Papel | Público-alvo |
+|---|-------------|-------|-------|--------------|
+| 1 | **App móvel (WOC)** | `walkyApp` | App iOS/Android que o estudante usa | Estudantes |
+| 2 | **Backend** | `walky-backend` | API REST + WebSockets, banco de dados | (serve todos) |
+| 3 | **Admin** | `walky-admin` | Painel administrativo (CoreUI) | Admins de campus/escola, moderadores |
+| 4 | **HQ** | `walky-hq` | Painel super-admin/analytics (shadcn) | Super-admins Walky (interno) |
+
+**Fluxo de dependência:** o **App**, o **Admin** e o **HQ** são todos clientes do **Backend**.
+Admin e HQ geram seus tipos TypeScript a partir do **Swagger/OpenAPI do backend**
+(`../walky-backend/swagger.json`). O App usa **Orval** para gerar hooks React Query do mesmo Swagger.
+
+```
+                    ┌──────────────────┐
+                    │   walky-backend  │  Node/Express/TS · MongoDB · Redis · Socket.io
+                    │   (API + WS)     │  GCP Cloud Run
+                    └────────┬─────────┘
+             ┌───────────────┼────────────────┐
+             │               │                │
+      ┌──────▼─────┐  ┌───────▼──────┐  ┌──────▼──────┐
+      │  walkyApp  │  │ walky-admin  │  │  walky-hq   │
+      │ RN/Expo    │  │ React+CoreUI │  │ React+shadcn│
+      │ (WOC)      │  │ (campus mgmt)│  │ (super-admin)│
+      └────────────┘  └──────────────┘  └─────────────┘
+```
+
+**Convenção de geração de tipos (comum aos 3 clientes):** todos consomem o contrato OpenAPI do
+backend. Mudança de contrato no backend → regenerar tipos/clients nos 3 frontends.
+
+---
+
+## 1. walkyApp — App móvel (WOC)
+
+**Propósito:** app móvel voltado ao estudante. Conexão entre pares, compartilhamento de
+localização em tempo real, mensagens, eventos e descoberta via mapa. Versão atual **3.5.2**.
+Repositório privado.
+
+### Stack
+- **React Native** 0.81.4 · **React** 19.1 · **TypeScript** 5.9 · **Expo** 54 (dev client)
+- **Gerenciador de pacotes:** Bun 1.2.4
+- **Estado:** Zustand 4.5 (`useGlobalStore`) + React Query 5.80 (server state)
+- **API client:** Orval 7.11 (gera hooks React Query a partir do Swagger) + Axios
+- **Navegação:** Expo Router 6 (file-based) + React Navigation 7
+- **UI/animação:** Reanimated 4, Gesture Handler, Gorhom Bottom Sheet, Unistyles 3, Lottie
+- **Tempo real:** socket.io-client 4.8 (WebSocket + polling fallback p/ WiFi restritivo do campus)
+- **Mapas/localização:** react-native-maps, Turf.js, Expo Location (com background tracking)
+- **Monitoramento/analytics:** Sentry, Firebase Analytics, Mixpanel, PostHog, Pendo
+- **Storage:** AsyncStorage, MMKV, Expo FileSystem
+
+### Estrutura (`src/`)
+- `app/` — rotas file-based do Expo Router: `(public)` (auth), `(main-v3)` (tabs autenticadas),
+  `(global-v3)` (modais), `(bottom-sheet)`
+- `features/` — módulos por feature: `auth`, `home`, `events-v3`, `chat-v3`, `explore`, `map`,
+  `peers`, `profile`, `spaces`, `ideas-v3`, `report`, `upgrades`, `sa-onboarding`, `bottomTabBar`
+- `components/common/` — 46+ componentes reutilizáveis
+- `services/` — camada de integração: `API/` (Axios), `analytics/`, `notifications/`, `location/`,
+  `featureFlags/`, `deeplink/`, `prefetch/`, `logging/`
+- `api/generated/` — cliente gerado por Orval (`walky.ts`) · `api/mutator/` — Axios custom
+- `hooks/` — hooks de socket por feature (`useEventSocket`, `useInviteSocket`, etc.)
+- `store/global/`, `query/`, `theme/`, `styles/unistyles.ts`, `utils/`
+
+### Features principais
+`auth` (login/onboarding), `home` (feed/descoberta), `events-v3` (criar/RSVP/chat de evento),
+`chat-v3` (DM + chat de evento em tempo real), `explore`+`map` (descoberta por mapa),
+`peers` (perfis/conexões), `profile`, `spaces` (comunidades), `ideas-v3`, `report` (moderação).
+
+### Integração com backend
+- **HTTP:** Axios em `src/services/API/`, base via env `BASE_URL`, Bearer token via `AuthService`,
+  refresh automático no 401, checagem de conectividade (netinfo) antes de requisitar.
+- **Socket:** `SocketProvider` em `src/utils/sockets/`, auth por token no handshake,
+  WebSocket + long-polling, reconnect tunado p/ mobile.
+- **Orval:** config em `orval.config.ts`, gera hooks em `src/api/generated/walky.ts`.
+  Scripts: `api:generate`, `api:generate:watch`, `api:fetch-swagger`.
+
+### Env vars
+`APP_ID`, `DISPLAY_NAME`, `BASE_URL`, `SOCKET_URL`, `GOOGLE_MAPS_API_KEY`, `SENTRY_DSN`,
+`MIXPANEL_TOKEN`, `POSTHOG_API_KEY`, `PENDO_API_KEY`, `USE_BACKGROUND_LOCATION`.
+Arquivos: `.env`, `.env.staging`, `.env.production`, `.env.e2e`.
+
+### Build/run
+- Scripts (Bun): `bun start`, `bun ios`, `bun android`, `bun type-check`, `bun lint`, `bun test`,
+  `bun test:e2e`, `bun api:generate`.
+- **EAS** (`eas.json`): perfis `development`, `development-device`, `preview`, `staging`,
+  `production`, `e2e-test`. iOS→TestFlight, Android→Firebase App Distribution/Google Play.
+- **Testes:** Jest (unit, 40+ mocks) + Maestro (E2E em YAML, `.maestro/`).
+
+### Convenção local (deste ambiente)
+- O simulador **sempre** aponta para o backend local (`walky-backend`), nunca staging/prod.
+- Backend local roda em `PORT=8080`; Metro usa 8081. `.env`: `BASE_URL=http://localhost:8080`,
+  `SOCKET_URL=ws://localhost:8080`. Após alterar `.env`, reiniciar Metro com
+  `npx expo start --dev-client --clear`.
+
+---
+
+## 2. walky-backend — API REST + WebSockets
+
+**Propósito:** API REST central da plataforma (serve app, admin e HQ). Node.js/Express/TypeScript
+com MongoDB, Redis e Socket.io. Deploy em **GCP Cloud Run**. Equipe pequena (2–3 devs), foco em
+velocidade e tempo real.
+
+### Stack
+- **TypeScript** (strict) · **Node 20+** · **Express** · **MongoDB 4.12+ / Mongoose 7.2** ·
+  **Redis** (location sync, tempo real) · **Socket.io 4.7**
+- **GCP:** Cloud Run (hosting), Cloud Build (CI/CD), Secret Manager, Cloud Storage (imagens),
+  Cloud Logging, Cloud Vision (moderação de imagem), Cloud Tasks
+- **Integrações:** Sentry, Firebase FCM (push), Expo Server SDK (push V2), SendGrid (email),
+  Twilio (SMS/OTP), Google Analytics 4, Google Places API, Replicate (upscale), Sharp, Rebrandly
+- **Auth:** JWT + SAML 2.0 (SSO universitário, ex.: FAU)
+- **Testes:** Jest 30 + ts-jest + MongoDB Memory Server
+
+### Estrutura (`src/`)
+- `index.ts` (entry + socket init), `config.ts`, `config/` (SAML, universidades, GCS, certs)
+- `routes/` (54 arquivos) — inclui `dualRouter.ts` (roteia `/api/*` **e** paths legados na raiz)
+- `controllers/` (70+), `services/` (61), `model/` (52 schemas Mongoose)
+- `middleware/` (11 — auth, rate limit de login, bad words, permissões)
+- `jobs/` (14 — cleanup de eventos, rollover de recorrentes, lembretes, agregação de analytics,
+  alertas, engagement scores)
+- `sockets/` — `walk.socket`, `chat.socket`, `explore.socket` + middleware de auth
+- `validators/`, `repositories/`, `migrations/` (98+ scripts), `scripts/` (54, seed/utilitários),
+  `templates/emails/`
+
+### Domínios principais
+Auth/RBAC · Users/Profiles · **Events** (core) · **Walks** (encontros espontâneos em tempo real) ·
+Chat/Messaging · Spaces/Places (locais do campus + Google Places) · Ideas · Interests/Communities ·
+Admin/Moderação · Notificações · Analytics/Métricas · Location/Discovery.
+
+### Banco de dados
+- **MongoDB Atlas.** Ambientes: **prod** (cluster `prod`), **staging**, dev local.
+  > ⚠️ Nota de contexto do time: o DB de produção se chama **`prod`** (não `walky`/`staging`).
+- **52 coleções** (models). Core: `users`, `events`, `walks`, `chat`, `spaces`, `ideas`,
+  `interests`. Relacionamentos: `eventInvites`, `peerRequests`, `walkInvites`, `spaceMember`.
+  Admin: `reports`, `roles`, `permissions`, `auditLogs`, `adminMessages`. Analytics:
+  `campusMetricsCache`, `campusAlerts`, `userActivityLog`, `profileView`. Places: `place`,
+  `placeType`, `popularPlace`, `campus`, `school`, `areaOfStudy`.
+
+### Auth
+- **JWT:** access 24h + refresh 7d. Payload `{ sub, email, role, tokenVersion, iat }`,
+  issuer `walky-app`, audience `walky-users`. `authMiddleware.ts` valida. Segredo em `JWT_SECRET`.
+  Revogação via incremento de `tokenVersion`.
+- **SAML 2.0:** SSO universitário (`saml-config-v2.ts`, certs em `config/certificates/`).
+- **RBAC:** roles Student/Faculty/Admin/Sales via IDs em env (`ADMIN_ROLE`, `STUDENT_ROLE`, etc.).
+
+### Tempo real (Socket.io)
+Namespaces separados: **walk** (convites/localização ao vivo), **chat** (DM + grupo),
+**explore** (feed de descoberta). Rate limit 15 conexões/min por IP (máx 5). Auth JWT no handshake.
+
+### Run local
+- Node 20+, MongoDB, Redis, `.env` (pedir ao time). `yarn install` → `yarn dev` → **porta 8081**
+  (ou `PORT`). No contexto deste ambiente, roda-se em **8080** para o simulador do app.
+- Scripts: `yarn dev|staging|prod|build|test|test:watch|lint|format|seed`.
+- **Swagger:** local `http://localhost:8081/api-docs/`, staging/prod idem sob os domínios.
+
+### Env vars (principais)
+`PORT`, `NODE_ENV`, `PROJECT_ID`, `MONGO_URI`, `REDIS_URL`, `JWT_SECRET`,
+`FIREBASE_PROJECT_ID/PRIVATE_KEY/CLIENT_EMAIL`, `TWILIO_*`, `SENDGRID_API_KEY`,
+`AWS_REGION/ACCESS_KEY_ID/SECRET_ACCESS_KEY/S3_BUCKET` (legado), `EXPO_ACCESS_TOKEN`,
+`ADMIN_ROLE/STUDENT_ROLE/FACULTY_ROLE/SALES_ROLE`, `REBRANDLY_API_KEY`.
+
+### Ambientes
+- Produção: `https://api.walkyapp.com` (branch `main`)
+- Staging: `https://staging.walkyapp.com` (branch `staging`)
+- Dev: `http://localhost:8081`
+
+---
+
+## 3. walky-admin — Painel administrativo (CoreUI)
+
+**Propósito:** painel para **admins de campus, admins de escola, moderadores e super-admins**
+gerenciarem estudantes, eventos, spaces, ideas, moderação e configurações de campus.
+
+### Stack
+- **TypeScript** 5.8 · **React** 19.1 · **React Router** v7.6 · **Vite** 7 · **Node** ≥20
+- **UI:** **CoreUI 5.7** + React Bootstrap 2.10 (framework de admin tradicional)
+- **Dados:** Axios 1.10 + React Query 5.82; tipos gerados via Swagger TypeScript API
+- **Estado:** React Context + React Query
+- **Viz:** Recharts 3.4 + Three.js (visualizações 3D no "Playground")
+- **Estilo:** CSS + Sass, design tokens via CSS variables (dual: CoreUI + tokens V2)
+- **Testes:** Vitest 4 + React Testing Library + MSW; checagem de `data-testid` e a11y
+
+### Estrutura (`src/`)
+`API/` (cliente Swagger gerado) · `components-v2/` (53 componentes) · `contexts/` (Auth, School,
+Campus, Theme) · `hooks/` (`useAuth`, `usePermissions`, `useTheme`) · `layout-v2/` (Sidebar+Topbar) ·
+`lib/` (logger, queryClient, matriz de permissões) · `pages-v2/` (telas) · `routes/v2Routes.tsx`
+(lazy loading) · `services/` (userService, campusService, etc.) · `styles-v2/` (tokens) · `test/`.
+
+### Telas principais
+- **Dashboards (6):** Engagement, Popular Features, User Interactions, Community, Student Safety,
+  Student Behavior
+- **Campus/Estudantes (4 listas):** Active, Banned, Deactivated, Disengaged
+- **Events:** Manager, Insights, Check-In Analytics
+- **Spaces:** Manager, Insights · **Ideas:** Manager, Insights
+- **Moderação:** Report Safety, Report History
+- **Administração (super/school admin):** Campuses (geofences, ambassadors), Ambassadors,
+  Role Management, Administrator Settings
+- **Playground:** 14 visualizações experimentais de dados
+- **Auth:** Login (+2FA opcional), recuperação de senha, troca forçada de senha
+
+### Integração com backend
+- Axios com interceptors. Base via `VITE_API_BASE_URL`
+  (prod `https://api.walkyapp.com/api`, local `http://localhost:8080|8081/api`).
+- Bearer token em localStorage + proteção CSRF (token de cookie em requests não-GET).
+- 401→logout/redirect login; 403 com `ACCOUNT_DEACTIVATED`→modal; retry (máx 3, pula 4xx exceto 408).
+- Camada de services + React Query (stale 5min, cache 10min).
+
+### Auth
+Token+user em localStorage. `useAuth()` reativo. **RBAC** com roles
+`super_admin`/`school_admin`/`campus_admin`/`moderator`/`walky_internal`; matriz em
+`src/lib/permissions.ts`; `<PermissionGuard>` e `<AuthGuard>` protegem rotas. Sync entre abas via
+storage events.
+
+### Build/run
+`npm run dev` (porta 5173), `build`, `preview`, `type-check`, `lint`, `test`, `test:coverage`,
+`check:testids`, `check:a11y`, `check:all`, `generate:api` (requer `../walky-backend/swagger.json`),
+`generate:icons`, `generate:images`. Deploy Vercel.
+Env: `VITE_API_BASE_URL`, `VITE_APP_NAME`, `VITE_ENV`, (opc.) `VITE_GOOGLE_MAPS_API_KEY`,
+`VITE_SENTRY_DSN`.
+
+---
+
+## 4. walky-hq — Painel super-admin / Analytics (shadcn)
+
+**Propósito:** dashboard de **HQ / super-admin** para o time interno Walky. Administração global da
+plataforma, analytics avançado, moderação e configuração de entidades core (usuários, escolas,
+campi, interesses, spaces, roles). É o sistema mais novo e sofisticado.
+
+### Stack
+- **React** 19 · **TypeScript** 5.7 (strict) · **Vite** 6 · **React Router** 6.22 · **Node** 18+ · Yarn
+- **UI:** **shadcn/ui** (Radix) + **Tailwind CSS** 3.3 + Lucide + Sonner (moderno, utility-first)
+- **Estado:** Zustand 5 (auth, persistido em localStorage) + React Query 5.67 + Context (school/campus)
+- **Dados:** Axios 1.8 (interceptors + refresh) + React Hook Form 7.54 + Zod 3.24
+- **Viz:** Recharts 3.3 · @dnd-kit (drag-and-drop) · Google Maps · Google Analytics Data API · Firebase 12
+
+### Estrutura (`src/`)
+`api/` (`client.ts` + 25+ services) · `components/` (`ui/` shadcn, `common/`, `analytics/`,
+`layout/`, `filters/`) · `pages/` (35+) · `router/` (`ProtectedRoute.tsx`) · `store/authStore.ts` ·
+`contexts/` (School, Campus) · `hooks/` · `types/` (100+ interfaces) · `utils/` · `lib/` (firebase, cn).
+
+### Telas principais (35+ rotas)
+Dashboard (overview) · Engagement · Users · Walks · Events · Schools · Places · Popular Places ·
+Interests · Interest Groups · Place Types · Surprise Rolls · Ideas · Spaces (+categorias) ·
+Roles (RBAC) · Reports · Banned Users · Areas of Study · Report Reasons · Deletion Requests ·
+Audit Logs · User Activity · Locked Users · Jobs (monitoramento de background jobs) · Messages · Profile.
+**Analytics avançado:** session, messaging, profile views, engagement, lifecycle, social graph,
+referrals, safety.
+
+### Integração com backend
+- `src/api/client.ts` (Axios). Base via `VITE_BASE_URL`
+  (dev `http://localhost:8080`, staging `https://staging.walkyapp.com`, prod `https://api.walkyapp.com`).
+- Interceptors: injeta Bearer token; no 401 faz refresh e re-fila requests; falha→logout/redirect.
+- Tokens em localStorage (`token`, `refresh_token`, `auth-storage`). 25+ services em `api/services/`.
+
+### Auth
+JWT com rotação de refresh token. Zustand `authStore` persiste `token/refreshToken/user/isAuthenticated`.
+`ProtectedRoute` checa `isAuthenticated`. Credencial de teste conhecida: `gal@walkyapp.com`.
+
+### Build/run
+`yarn dev` (porta 5173), `build`, `lint`, `preview`. Deploy Vercel (`vercel.json`, saída `dist/`).
+Env: `VITE_BASE_URL` (obrigatório), `VITE_GA_PROPERTY_ID` (opcional).
+
+---
+
+## 5. Admin vs HQ — como diferem
+
+| Aspecto | walky-admin | walky-hq |
+|--------|-------------|----------|
+| UI | CoreUI 5 + Bootstrap | shadcn/ui + Tailwind |
+| Build | Vite 7 | Vite 6 |
+| Estado | Context + React Query | Zustand + React Query |
+| Público | Admins de campus/escola, moderadores | Super-admins internos Walky |
+| Ênfase | Gestão operacional por campus, moderação | Analytics global avançado, config de entidades core |
+| Maturidade | Sistema com CoreUI, orientado a operação | Sistema mais novo/sofisticado |
+
+Há **sobreposição funcional** (ambos têm users, events, spaces, ideas, reports, roles, campus).
+A distinção é de **escopo e público**: Admin é operação por campus/escola; HQ é super-admin/analytics global.
+
+---
+
+## 6. Fatos transversais úteis para a IA
+
+- **Contrato único:** os 3 frontends derivam tipos do **Swagger do backend**. Documentar o backend
+  primeiro dá base para os clients.
+- **Auth consistente:** JWT (access + refresh) em toda a stack; RBAC por roles; backend também
+  suporta SAML SSO universitário.
+- **Tempo real:** Socket.io no backend (namespaces walk/chat/explore) consumido pelo app.
+- **Multi-tenant por campus/escola:** entidades `school`/`campus` permeiam todos os repos;
+  contexts de School/Campus existem tanto no Admin quanto no HQ.
+- **Domínios de negócio compartilhados** (vocabulário comum a documentar uma vez): Users, Events,
+  Walks, Chat, Spaces/Places, Ideas, Interests, Reports/Moderação, Analytics, Campus/School, Roles.
+- **Deploy:** backend em GCP Cloud Run; Admin e HQ em Vercel; App via EAS (TestFlight / Firebase / Play).
+- **Ambientes backend:** prod (`api.walkyapp.com`), staging (`staging.walkyapp.com`), local (8081).
+
+---
+
+## 7. Localização dos repositórios
+
+```
+/Volumes/SSDDEV/DEV_PROJETOS/
+├── walkyApp/        # App móvel (WOC)  — React Native / Expo
+├── walky-backend/   # API + WS         — Node / Express / Mongo / Redis
+├── walky-admin/     # Admin            — React / CoreUI / Vite
+└── walky-hq/        # HQ super-admin   — React / shadcn / Vite
+```
+
+Cada repositório tem seu próprio `README.md`; `walky-hq` e `walky-admin` também têm um
+`claude.md`/`CLAUDE.md` com notas de desenvolvimento.
+
+---
+
+## 8. Como a IA deve usar este documento
+
+1. **Entender o conjunto** antes de documentar qualquer repo isolado (dependências e contrato comum).
+2. **Escrever um prompt de documentação** que:
+   - documente o **backend primeiro** (é a fonte do contrato/tipos e dos domínios de negócio);
+   - reutilize o **vocabulário de domínio** da seção 6 para manter consistência entre repos;
+   - para cada frontend, cubra: propósito/público, stack, estrutura de pastas, telas/features,
+     integração com backend (base URL/env/auth), build/run e deploy;
+   - destaque **diferenças Admin vs HQ** para não duplicar/confundir.
+3. **Manter um glossário único** dos domínios (Events, Walks, Spaces, Ideas, Campus/School, Roles…)
+   referenciado pelos quatro repositórios.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,49 @@
+# Documentação — walky-admin
+
+Documentação técnica do **walky-admin**, o painel administrativo (React 19 + CoreUI + Vite) da
+plataforma Walky. Público: admins de campus/escola, moderadores e super-admins.
+
+> Para a visão do **ecossistema inteiro** (os 4 repositórios), veja
+> [`../AI_CONTEXT.md`](../AI_CONTEXT.md). O admin é **cliente do backend** e gera seus tipos a partir
+> do Swagger de `../walky-backend/swagger.json`.
+
+---
+
+## Índice
+
+| # | Documento | O que cobre |
+|---|-----------|-------------|
+| 1 | [overview.md](overview.md) | Propósito, papel no ecossistema, os 5 roles do RBAC e a **stack** com o porquê de cada lib |
+| 2 | [architecture.md](architecture.md) | Providers, React Router v7 + lazy, service layer sobre Axios gerado, React Query, RBAC, multi-tenant (diagramas) |
+| 3 | [folder-structure.md](folder-structure.md) | Cada diretório e o significado do sufixo `-v2` (redesign da UI vs. fundação) |
+| 4 | [workflows.md](workflows.md) | 12 fluxos de negócio + 3 técnicos: login/OTP, sync entre abas, RBAC, dashboards, moderação, campus/geofences… |
+| 5 | [business-rules.md](business-rules.md) | Matriz de permissões por role, durações de ban, regras de moderação, validações, rota→recurso |
+| 6 | [integrations.md](integrations.md) | Backend/Axios (CSRF, interceptors), Swagger TypeScript API, Google Maps |
+| 7 | [conventions.md](conventions.md) | `-v2`, `.tsx`+`.css` namespaced, `data-testid` obrigatório, a11y, barrel exports, design tokens + dark mode |
+| 8 | [development.md](development.md) | Rodar (`npm run dev` 5173), nova página com rota lazy + PermissionGuard, `generate:api`, MSW, `check:all` |
+| 9 | [deployment.md](deployment.md) | Env vars, scripts, Vite build, Vitest+RTL+MSW, workflows CI, deploy Vercel |
+| 10 | [troubleshooting.md](troubleshooting.md) | 12 sintomas→solução (backend/CORS, 401 loop, 403 modal, tipos, testids, a11y, dark mode, SPA) |
+| 11 | [ai-reference.md](ai-reference.md) | Referência densa para LLMs: mapa de módulos, fluxos auth/RBAC, regras e armadilhas |
+
+> `TESTING.md` (pré-existente) foi preservado e trata do framework de testes em detalhe.
+
+---
+
+## Notas importantes descobertas na análise do código
+
+- **Sem refresh token no admin:** todo 401 desloga (diverge do app/HQ). O RBAC do cliente é
+  **UX/defesa-em-profundidade**; a autoridade final é do backend.
+- **`.env` versionado aponta hoje para staging** (`https://staging.walkyapp.com/api`), não para local.
+- **Google Maps com chave hardcoded** em `CampusBoundary.tsx`; `VITE_GOOGLE_MAPS_API_KEY` não é lida.
+  A única env var de app realmente consumida é `VITE_API_BASE_URL`.
+- **Sem Sentry:** `VITE_SENTRY_DSN` é só comentário no `.env.example`; há um logger próprio
+  (`src/lib/logger.ts`).
+- **Camada legada não usada:** `reportService.ts` (endpoints `adminReports*` sem `v2`) e os hooks
+  `useSchoolFilter`/`useCampusFilter`/`useDashboardPrefetch` estão definidos mas não são invocados; o
+  filtro multi-tenant efetivo passa `schoolId`/`campusId` direto nas queries.
+- **`super_admin`/`school_admin`/`campus_admin` têm direitos idênticos por recurso** na matriz; a
+  diferença de escopo é aplicada por campus/escola e pelo backend. Roles `editor`/`staff`/`viewer`
+  passam no login mas caem em `noPermissions`.
+- **Arquivos em `src/API/*` são gerados** (`@ts-nocheck`) — não editar à mão.
+
+_Gerada por análise direta do código. Mantenha sincronizada ao alterar o código._

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,49 +1,51 @@
-# Documentação — walky-admin
+# Documentation — walky-admin
 
-Documentação técnica do **walky-admin**, o painel administrativo (React 19 + CoreUI + Vite) da
-plataforma Walky. Público: admins de campus/escola, moderadores e super-admins.
+Technical documentation for **walky-admin**, the administrative panel (React 19 + CoreUI + Vite) of the
+Walky platform. Audience: campus/school admins, moderators, and super-admins.
 
-> Para a visão do **ecossistema inteiro** (os 4 repositórios), veja
-> [`../AI_CONTEXT.md`](../AI_CONTEXT.md). O admin é **cliente do backend** e gera seus tipos a partir
-> do Swagger de `../walky-backend/swagger.json`.
+> For the view of the **entire ecosystem** (all 4 repositories), see
+> [`../AI_CONTEXT.md`](../AI_CONTEXT.md). The admin is a **client of the backend** and generates its types from
+> the Swagger of `../walky-backend/swagger.json`.
 
 ---
 
-## Índice
+## Table of Contents
 
-| # | Documento | O que cobre |
+| # | Document | What it covers |
 |---|-----------|-------------|
-| 1 | [overview.md](overview.md) | Propósito, papel no ecossistema, os 5 roles do RBAC e a **stack** com o porquê de cada lib |
-| 2 | [architecture.md](architecture.md) | Providers, React Router v7 + lazy, service layer sobre Axios gerado, React Query, RBAC, multi-tenant (diagramas) |
-| 3 | [folder-structure.md](folder-structure.md) | Cada diretório e o significado do sufixo `-v2` (redesign da UI vs. fundação) |
-| 4 | [workflows.md](workflows.md) | 12 fluxos de negócio + 3 técnicos: login/OTP, sync entre abas, RBAC, dashboards, moderação, campus/geofences… |
-| 5 | [business-rules.md](business-rules.md) | Matriz de permissões por role, durações de ban, regras de moderação, validações, rota→recurso |
+| 1 | [overview.md](overview.md) | Purpose, role in the ecosystem, the 5 RBAC roles, and the **stack** with the rationale for each lib |
+| 2 | [architecture.md](architecture.md) | Providers, React Router v7 + lazy, service layer over generated Axios, React Query, RBAC, multi-tenant (diagrams) |
+| 3 | [folder-structure.md](folder-structure.md) | Each directory and the meaning of the `-v2` suffix (UI redesign vs. foundation) |
+| 4 | [workflows.md](workflows.md) | 12 business flows + 3 technical: login/OTP, cross-tab sync, RBAC, dashboards, moderation, campus/geofences… |
+| 5 | [business-rules.md](business-rules.md) | Permission matrix per role, ban durations, moderation rules, validations, route→resource |
 | 6 | [integrations.md](integrations.md) | Backend/Axios (CSRF, interceptors), Swagger TypeScript API, Google Maps |
-| 7 | [conventions.md](conventions.md) | `-v2`, `.tsx`+`.css` namespaced, `data-testid` obrigatório, a11y, barrel exports, design tokens + dark mode |
-| 8 | [development.md](development.md) | Rodar (`npm run dev` 5173), nova página com rota lazy + PermissionGuard, `generate:api`, MSW, `check:all` |
-| 9 | [deployment.md](deployment.md) | Env vars, scripts, Vite build, Vitest+RTL+MSW, workflows CI, deploy Vercel |
-| 10 | [troubleshooting.md](troubleshooting.md) | 12 sintomas→solução (backend/CORS, 401 loop, 403 modal, tipos, testids, a11y, dark mode, SPA) |
-| 11 | [ai-reference.md](ai-reference.md) | Referência densa para LLMs: mapa de módulos, fluxos auth/RBAC, regras e armadilhas |
+| 7 | [conventions.md](conventions.md) | `-v2`, namespaced `.tsx`+`.css`, required `data-testid`, a11y, barrel exports, design tokens + dark mode |
+| 8 | [development.md](development.md) | Running (`npm run dev` 5173), new page with lazy route + PermissionGuard, `generate:api`, MSW, `check:all` |
+| 9 | [deployment.md](deployment.md) | Env vars, scripts, Vite build, Vitest+RTL+MSW, CI workflows, Vercel deploy |
+| 10 | [troubleshooting.md](troubleshooting.md) | 12 symptoms→solution (backend/CORS, 401 loop, 403 modal, types, testids, a11y, dark mode, SPA) |
+| 11 | [ai-reference.md](ai-reference.md) | Dense reference for LLMs: module map, auth/RBAC flows, rules and pitfalls |
 
-> `TESTING.md` (pré-existente) foi preservado e trata do framework de testes em detalhe.
+> `TESTING.md` (pre-existing) has been preserved and covers the testing framework in detail.
 
 ---
 
-## Notas importantes descobertas na análise do código
+## Important notes discovered during code analysis
 
-- **Sem refresh token no admin:** todo 401 desloga (diverge do app/HQ). O RBAC do cliente é
-  **UX/defesa-em-profundidade**; a autoridade final é do backend.
-- **`.env` versionado aponta hoje para staging** (`https://staging.walkyapp.com/api`), não para local.
-- **Google Maps com chave hardcoded** em `CampusBoundary.tsx`; `VITE_GOOGLE_MAPS_API_KEY` não é lida.
-  A única env var de app realmente consumida é `VITE_API_BASE_URL`.
-- **Sem Sentry:** `VITE_SENTRY_DSN` é só comentário no `.env.example`; há um logger próprio
+- **No refresh token in the admin:** every 401 logs the user out (diverges from the app/HQ). The client-side
+  RBAC is **UX/defense-in-depth**; the final authority is the backend.
+- **Environment configuration:** your local `.env` (git-ignored) may point to staging
+  (`https://staging.walkyapp.com/api`); the committed `.env.example` defaults to production
+  (`https://api.walkyapp.com/api`).
+- **Google Maps with a hardcoded key** in `CampusBoundary.tsx`; `VITE_GOOGLE_MAPS_API_KEY` is not read.
+  The only app env var actually consumed is `VITE_API_BASE_URL`.
+- **No Sentry:** `VITE_SENTRY_DSN` is only a comment in `.env.example`; there is a home-grown logger
   (`src/lib/logger.ts`).
-- **Camada legada não usada:** `reportService.ts` (endpoints `adminReports*` sem `v2`) e os hooks
-  `useSchoolFilter`/`useCampusFilter`/`useDashboardPrefetch` estão definidos mas não são invocados; o
-  filtro multi-tenant efetivo passa `schoolId`/`campusId` direto nas queries.
-- **`super_admin`/`school_admin`/`campus_admin` têm direitos idênticos por recurso** na matriz; a
-  diferença de escopo é aplicada por campus/escola e pelo backend. Roles `editor`/`staff`/`viewer`
-  passam no login mas caem em `noPermissions`.
-- **Arquivos em `src/API/*` são gerados** (`@ts-nocheck`) — não editar à mão.
+- **Unused legacy layer:** `reportService.ts` (endpoints `adminReports*` without `v2`) and the hooks
+  `useSchoolFilter`/`useCampusFilter`/`useDashboardPrefetch` are defined but never invoked; the effective
+  multi-tenant filter passes `schoolId`/`campusId` directly in the queries.
+- **`super_admin`/`school_admin`/`campus_admin` have identical rights per resource** in the matrix; the
+  scope difference is enforced per campus/school and by the backend. The `editor`/`staff`/`viewer` roles
+  pass login but land on `noPermissions`.
+- **Files under `src/API/*` are generated** (`@ts-nocheck`) — do not edit by hand.
 
-_Gerada por análise direta do código. Mantenha sincronizada ao alterar o código._
+_Generated by direct code analysis. Keep in sync when changing the code._

--- a/docs/ai-reference.md
+++ b/docs/ai-reference.md
@@ -1,60 +1,60 @@
 # AI Reference — walky-admin
 
-> Referência densa para LLMs. Mapa de diretórios, arquivos-chave (paths absolutos), convenções,
-> fluxos principais, regras e armadilhas. Fonte-de-verdade é o código; ver também
+> Dense reference for LLMs. Directory map, key files (absolute paths), conventions,
+> main flows, rules, and pitfalls. The source of truth is the code; see also
 > [conventions.md](./conventions.md) · [development.md](./development.md) · [troubleshooting.md](./troubleshooting.md).
 
-## Índice
+## Table of Contents
 
-- [Identidade](#identidade)
+- [Identity](#identidade)
 - [Stack](#stack)
-- [Mapa de diretórios](#mapa-de-diretórios)
-- [Arquivos-chave](#arquivos-chave)
-- [Fluxo de auth (login → guarda de rota)](#fluxo-de-auth-login--guarda-de-rota)
-- [Fluxo de RBAC (permissões)](#fluxo-de-rbac-permissões)
-- [Fluxo de dados (React Query + services + API gerada)](#fluxo-de-dados-react-query--services--api-gerada)
-- [Convenções obrigatórias](#convenções-obrigatórias)
-- [Comandos](#comandos)
-- [Regras-chave](#regras-chave)
-- [Limitações / armadilhas](#limitações--armadilhas)
+- [Directory map](#directory-map)
+- [Key files](#arquivos-chave)
+- [Auth flow (login → route guard)](#fluxo-de-auth-login--guarda-de-rota)
+- [RBAC flow (permissions)](#rbac-flow-permissions)
+- [Data flow (React Query + services + generated API)](#fluxo-de-dados-react-query--services--api-gerada)
+- [Required conventions](#required-conventions)
+- [Commands](#comandos)
+- [Key rules](#regras-chave)
+- [Limitations / pitfalls](#limitations--pitfalls)
 
 ---
 
-## Identidade
+## Identity
 
-Painel administrativo do ecossistema **Walky** (rede social de campus). Público: `super_admin`,
-`school_admin`, `campus_admin`, `moderator`, `walky_internal`. Cliente do `walky-backend` (deriva tipos
-do Swagger). Deploy em Vercel. Repo em `/Volumes/SSDDEV/DEV_PROJETOS/walky-admin`.
-Contexto do ecossistema: `/Volumes/SSDDEV/DEV_PROJETOS/walky-admin/AI_CONTEXT.md`.
+Admin panel for the **Walky** ecosystem (campus social network). Audience: `super_admin`,
+`school_admin`, `campus_admin`, `moderator`, `walky_internal`. Client of `walky-backend` (derives its
+types from Swagger). Deployed on Vercel. Repo at `/Volumes/SSDDEV/DEV_PROJETOS/walky-admin`.
+Ecosystem context: `/Volumes/SSDDEV/DEV_PROJETOS/walky-admin/AI_CONTEXT.md`.
 
 ## Stack
 
 React 19.1 · TypeScript 5.8 (strict, project references) · Vite 7 · React Router 7.6 · CoreUI 5.7 +
 React Bootstrap 2.10 · React Query 5.82 · Axios 1.10 · Recharts 3.4 + Three.js (Playground) · Vitest 4
-+ RTL + MSW 2 · Sass. Node ≥ 20 (Vercel/`.nvmrc`: 22). Package manager efetivo: **yarn** (husky/CI).
++ RTL + MSW 2 · Sass. Node ≥ 20 (Vercel/`.nvmrc`: 22). Effective package manager: **yarn** (husky/CI).
 
-## Mapa de diretórios
+## Directory map
 
 ```
 /Volumes/SSDDEV/DEV_PROJETOS/walky-admin/
 ├── src/
-│   ├── API/                 # cliente HTTP GERADO do Swagger (WalkyAPI.ts) + index.ts (Axios, interceptors)
-│   ├── components-v2/        # 53 componentes reutilizáveis (pasta = .tsx + .css + index.ts)
-│   │   └── index.ts          # barrel agregador
-│   ├── pages-v2/             # telas por feature (Admin, Campus, Dashboard, Events, Ideas, Spaces,
+│   ├── API/                 # HTTP client GENERATED from Swagger (WalkyAPI.ts) + index.ts (Axios, interceptors)
+│   ├── components-v2/        # 52 reusable components (folder = .tsx + .css + index.ts)
+│   │   └── index.ts          # barrel aggregator
+│   ├── pages-v2/             # feature screens (Admin, Campus, Dashboard, Events, Ideas, Spaces,
 │   │                         #  Moderation, Playground, LoginV2, RecoverPasswordV2, ForcePasswordChange)
 │   ├── layout-v2/            # LayoutV2 + SidebarV2 + TopbarV2
-│   ├── routes/v2Routes.tsx   # rotas lazy + PermissionGuard
+│   ├── routes/v2Routes.tsx   # lazy routes + PermissionGuard
 │   ├── contexts/             # School, Campus, Dashboard, DeactivatedUser, Theme
-│   ├── hooks/                # useAuth, usePermissions, useDebounce, useMediaQuery, useTheme, filtros
+│   ├── hooks/                # useAuth, usePermissions, useDebounce, useMediaQuery, useTheme, filters
 │   ├── lib/                  # permissions.ts, queryClient.ts, logger.ts, utils/
 │   ├── services/             # userService, campusService, reportService, rolesService, ... (12)
 │   ├── styles-v2/            # design-tokens.css/.ts, theme-variables.css, global.css, ThemeComponents.css
-│   ├── theme.ts              # getTheme(isDark) → objeto de cores
+│   ├── theme.ts              # getTheme(isDark) → color object
 │   ├── test/                 # setup.ts, test-utils.tsx, server.ts, handlers.ts, factories.ts
-│   ├── App.tsx / main.tsx    # shell + montagem de providers
-│   ├── assets-v2/ types/     # assets novos, tipos
-│   └── (legado) components/ pages/ assets/  # descontinuando
+│   ├── App.tsx / main.tsx    # shell + provider mounting
+│   ├── assets-v2/ types/     # new assets, types
+│   └── (legacy) components/ pages/ assets/  # being deprecated
 ├── scripts/                  # check-test-ids.js, check-accessibility.js, generate-icons/images.cjs
 ├── docs/                     # conventions/development/troubleshooting/ai-reference + TESTING.md
 ├── .husky/pre-commit         # build → testids → a11y → lint-staged
@@ -63,111 +63,114 @@ React Bootstrap 2.10 · React Query 5.82 · Axios 1.10 · Recharts 3.4 + Three.j
 └── .env / .env.example
 ```
 
-## Arquivos-chave
+## Key files
 
-| Path | Papel |
-|------|-------|
-| `src/main.tsx` | Monta providers: `QueryClientProvider` → `ThemeProvider` → `SchoolProvider` → `BrowserRouter` → `App`. Importa CSS CoreUI + tokens V2. |
-| `src/App.tsx` | Rotas públicas (`/login`, `/recover-password`, `/force-password-change`) + `AuthGuard` envolvendo `V2Routes`. Toaster (`react-hot-toast`). Alterna `body.dark-mode`. |
-| `src/routes/v2Routes.tsx` | Todas as rotas autenticadas, lazy, sob `LayoutV2`, cada uma com `PermissionGuard`. Providers `CampusProvider`/`DashboardProvider`. |
-| `src/API/index.ts` | Cria `apiClient` (do `WalkyAPI.ts`), remove `/api` do baseURL, interceptors: Bearer token, CSRF em não-GET, 401→logout, 403(`ACCOUNT_DEACTIVATED`)→modal. Exporta `apiClient`, `httpClient`, `API`. |
-| `src/API/WalkyAPI.ts` | Cliente Axios tipado GERADO (não editar). |
+| Path | Role |
+|------|------|
+| `src/main.tsx` | Mounts providers: `QueryClientProvider` → `ThemeProvider` → `SchoolProvider` → `BrowserRouter` → `App`. Imports CoreUI CSS + V2 tokens. |
+| `src/App.tsx` | Public routes (`/login`, `/recover-password`, `/force-password-change`) + `AuthGuard` wrapping `V2Routes`. Toaster (`react-hot-toast`). Toggles `body.dark-mode`. |
+| `src/routes/v2Routes.tsx` | All authenticated routes, lazy, under `LayoutV2`, each with a `PermissionGuard`. `CampusProvider`/`DashboardProvider` providers. |
+| `src/API/index.ts` | Creates `apiClient` (from `WalkyAPI.ts`), strips `/api` from the baseURL, interceptors: Bearer token, CSRF on non-GET, 401→logout, 403(`ACCOUNT_DEACTIVATED`)→modal. Exports `apiClient`, `httpClient`, `API`. |
+| `src/API/WalkyAPI.ts` | Typed Axios client, GENERATED (do not edit). |
 | `src/lib/permissions.ts` | `permissionMatrix`, `hasPermission`, `routeResourceMap`, `roleHierarchy`, display-name maps. |
-| `src/hooks/useAuth.ts` | Lê `localStorage` (`token`,`user`), sincroniza entre abas (`storage`/`auth:user-updated`), `updateUser`. |
+| `src/hooks/useAuth.ts` | Reads `localStorage` (`token`,`user`), syncs across tabs (`storage`/`auth:user-updated`), `updateUser`. |
 | `src/hooks/usePermissions.ts` | `can/canRead/canUpdate/...`, flags `isSuperAdmin/isModerator/...`. |
-| `src/components-v2/AuthGuard/AuthGuard.tsx` | Redireciona não-autenticados p/ `/login`; `null` enquanto `isLoading`. |
-| `src/components-v2/PermissionGuard/PermissionGuard.tsx` | Guarda por `resource`+`action`; `fallback` `hidden`/`redirect`/node. HOC `withPermission`. |
-| `src/lib/queryClient.ts` | QueryClient (stale 5min, gc 10min, retry pula 4xx≠408) + `queryKeys` factory. |
-| `src/lib/logger.ts` | Wrapper de console (único autorizado); DEV-gated para debug/info. |
-| `src/styles-v2/design-tokens.css` | Tokens `--v2-*` + overrides dark sob `[data-coreui-theme="dark"]`/`[data-theme="dark"]`. |
-| `src/contexts/ThemeProvider.tsx` | Estado de tema, seta atributos no `<html>`, injeta `--app-*`. |
-| `src/contexts/SchoolContext.tsx` / `CampusContext.tsx` | Seleção multi-tenant (school/campus), persistida em `localStorage`. |
-| `src/test/test-utils.tsx` | `renderWithProviders` com stack real de providers + MemoryRouter. |
-| `src/test/handlers.ts` / `server.ts` / `factories.ts` | MSW default + server + builders. |
-| `scripts/check-test-ids.js` / `check-accessibility.js` | Gates de qualidade (pre-commit + CI). |
+| `src/components-v2/AuthGuard/AuthGuard.tsx` | Redirects unauthenticated users to `/login`; `null` while `isLoading`. |
+| `src/components-v2/PermissionGuard/PermissionGuard.tsx` | Guards by `resource`+`action`; `fallback` `hidden`/`redirect`/node. `withPermission` HOC. |
+| `src/lib/queryClient.ts` | QueryClient (stale 5min, gc 10min, retry skips 4xx≠408) + `queryKeys` factory. |
+| `src/lib/logger.ts` | Console wrapper (the only authorized one); DEV-gated for debug/info. |
+| `src/styles-v2/design-tokens.css` | `--v2-*` tokens + dark overrides under `[data-coreui-theme="dark"]`/`[data-theme="dark"]`. |
+| `src/contexts/ThemeProvider.tsx` | Theme state, sets attributes on `<html>`, injects `--app-*`. |
+| `src/contexts/SchoolContext.tsx` / `CampusContext.tsx` | Multi-tenant selection (school/campus), persisted in `localStorage`. |
+| `src/test/test-utils.tsx` | `renderWithProviders` with the real provider stack + MemoryRouter. |
+| `src/test/handlers.ts` / `server.ts` / `factories.ts` | MSW defaults + server + builders. |
+| `scripts/check-test-ids.js` / `check-accessibility.js` | Quality gates (pre-commit + CI). |
 
-## Fluxo de auth (login → guarda de rota)
+## Auth flow (login → route guard)
 
-- Login (`src/pages-v2/LoginV2/`) grava `token` e `user` em `localStorage`; 2FA opcional; troca forçada
-  de senha em `/force-password-change`.
-- `useAuth` deriva `isAuthenticated` de `localStorage`; escuta `storage` (multi-aba) e evento custom
-  `auth:user-updated`. `updateUser(null)` faz logout local.
-- `AuthGuard` (em `App.tsx`, rota `/*`) barra não-autenticados; renderiza `null` durante `isLoading`
-  (evita flash de redirect no refresh).
-- Interceptors (`src/API/index.ts`): injetam `Authorization: Bearer <token>`; em **401** removem token
-  e navegam para `/login`. **Não há refresh automático de token neste repo.**
-- CSRF: em requests não-GET, lê cookie (`csrf_cookie_rr`/`XSRF-TOKEN`/…) e envia `X-CSRF-Token`/
-  `X-XSRF-Token`; Axios com `withCredentials: true`.
-- 403 com `code` `ACCOUNT_DEACTIVATED`/`USER_DEACTIVATED` → `triggerDeactivatedModal()`.
+- Login (`src/pages-v2/LoginV2/`) writes `token` and `user` to `localStorage`; 2FA optional; forced
+  password change at `/force-password-change`.
+- `useAuth` derives `isAuthenticated` from `localStorage`; listens for `storage` (multi-tab) and the custom
+  `auth:user-updated` event. `updateUser(null)` performs a local logout.
+- `AuthGuard` (in `App.tsx`, route `/*`) blocks unauthenticated users; renders `null` during `isLoading`
+  (avoids a redirect flash on refresh).
+- Interceptors (`src/API/index.ts`): inject `Authorization: Bearer <token>`; on **401** they remove the token
+  and navigate to `/login`. **There is no automatic token refresh in this repo.**
+- CSRF: on non-GET requests, reads a cookie (`csrf_cookie_rr`/`XSRF-TOKEN`/…) and sends `X-CSRF-Token`/
+  `X-XSRF-Token`; Axios with `withCredentials: true`.
+- 403 with `code` `ACCOUNT_DEACTIVATED`/`USER_DEACTIVATED` → `triggerDeactivatedModal()`.
 
-## Fluxo de RBAC (permissões)
+## RBAC flow (permissions)
 
 - Roles: `super_admin`, `school_admin`, `campus_admin`, `moderator`, `walky_internal`.
-- Ações: `read`, `create`, `update`, `delete`, `export`, `manage`.
+- Actions: `read`, `create`, `update`, `delete`, `export`, `manage`.
 - `permissionMatrix[role][resource] → ResourcePermission` (`src/lib/permissions.ts`).
-  Ex.: `super_admin.events_manager = readUpdateDeleteExport`; `moderator.active_students = noPermissions`,
-  mas `moderator.report_safety = readUpdateExport`; `walky_internal` é leitura-só (sem reports).
-- Rotas: `PermissionGuard resource=... fallback="redirect"` em `v2Routes.tsx`. `routeResourceMap`
-  mapeia path→resource (`canAccessRoute`); path não mapeado é liberado por default.
-- UI inline: `PermissionGuard fallback="hidden"` ou `withPermission`; ou `usePermissions().can(...)`.
-- Hierarquia de atribuição de role: `roleHierarchy` (super→school/campus/moderator; school→campus/
+  E.g., `super_admin.events_manager = readUpdateDeleteExport`; `moderator.active_students = noPermissions`,
+  but `moderator.report_safety = readUpdateExport`; `walky_internal` is read-only (no reports).
+- Routes: `PermissionGuard resource=... fallback="redirect"` in `v2Routes.tsx`. `routeResourceMap`
+  maps path→resource (`canAccessRoute`); an unmapped path is allowed by default.
+- Inline UI: `PermissionGuard fallback="hidden"` or `withPermission`; or `usePermissions().can(...)`.
+- Role-assignment hierarchy: `roleHierarchy` (super→school/campus/moderator; school→campus/
   moderator; campus→moderator). Helpers `getAssignableRoles`, `canAssignRole(ByDisplayName)`.
 
-## Fluxo de dados (React Query + services + API gerada)
+## Data flow (React Query + services + generated API)
 
 ```
-Componente (pages-v2)
-  └─ useQuery({ queryKey: [feature, ...filtros, school?._id, campus?._id], queryFn })
-       └─ service (src/services/*)  ── ou ──  apiClient.api.<método>() direto
+Component (pages-v2)
+  └─ useQuery({ queryKey: [feature, ...filters, school?._id, campus?._id], queryFn })
+       └─ service (src/services/*)  ── or ──  apiClient.api.<method>() directly
             └─ apiClient (src/API/index.ts)  # Axios + interceptors
-                 └─ WalkyAPI.ts (GERADO do swagger.json do backend)
+                 └─ WalkyAPI.ts (GENERATED from the backend's swagger.json)
                       └─ walky-backend
 ```
 
-- `queryKey` inclui **todos** os filtros + `selectedSchool?._id`/`selectedCampus?._id` (multi-tenant).
-- Buscas de texto passam por `useDebounce` (500 ms) antes da key.
-- Paginação: `placeholderData: keepPreviousData`.
-- Services normalizam a resposta (campos opcionais com `??`/`||`), logam via `logger`, `throw` no erro.
-- Contextos `School`/`Campus` selecionam o tenant; persistidos em `localStorage` (`selectedSchool`, etc.).
+- The `queryKey` includes **all** filters + `selectedSchool?._id`/`selectedCampus?._id` (multi-tenant).
+- The multi-tenant filter passes `campus_id`/`schoolId` **explicitly per query**; the hooks
+  `useCampusFilter`/`useSchoolFilter`/`useDashboardPrefetch` are defined but not invoked.
+- Text searches go through `useDebounce` (500 ms) before the key.
+- Pagination: `placeholderData: keepPreviousData`.
+- Services normalize the response (optional fields with `??`/`||`), log via `logger`, and `throw` on error.
+- The `School`/`Campus` contexts select the tenant; persisted in `localStorage` (`selectedSchool`, etc.).
 
-## Convenções obrigatórias
+## Required conventions
 
-- Código novo em pastas **`-v2`** (components-v2/pages-v2/layout-v2/styles-v2/assets-v2). Legado em EOL.
-- Componente = pasta `Name/` com `Name.tsx` + `Name.css` (classes prefixadas `name-*`, sem CSS Modules) + `index.ts`.
-- `data-testid` em todo `<button>`/`<input>`/`<form>` de pages-v2/components-v2.
+- New code goes in **`-v2`** folders (components-v2/pages-v2/layout-v2/styles-v2/assets-v2). Legacy is EOL.
+- A component = a `Name/` folder with `Name.tsx` + `Name.css` (classes prefixed `name-*`, no CSS Modules) + `index.ts`.
+- `data-testid` on every `<button>`/`<input>`/`<form>` in pages-v2/components-v2.
 - a11y WCAG 2.1 AA (alt, aria-label, labels, aria-checked/selected, focus styles).
-- Importar via barrel raiz (`../../../components-v2`), não do arquivo interno.
-- Server state via React Query; nunca `console.*` (usar `logger`).
-- Cores/spacing via tokens `--v2-*` para herdar dark mode.
-- Teste ao lado (`Foo.test.tsx`), render com `renderWithProviders`, MSW para rede.
+- Import via the root barrel (`../../../components-v2`), not the internal file.
+- Server state via React Query; never `console.*` (use `logger`).
+- Colors/spacing via `--v2-*` tokens so dark mode is inherited.
+- Tests alongside (`Foo.test.tsx`), render with `renderWithProviders`, MSW for the network.
 
-## Comandos
+## Commands
 
 `yarn dev` (5173) · `yarn build` (`tsc -b && vite build`) · `yarn test [--run]` · `yarn test:coverage`
 · `yarn check:testids` · `yarn check:a11y` · `yarn check:all` · `yarn lint` · `yarn type-check`
-· `yarn generate:api` (requer `../walky-backend/swagger.json`) · `generate:icons`/`generate:images`.
-Env: `VITE_API_BASE_URL` (terminar em `/api`), `VITE_APP_NAME`, `VITE_ENV`, opc. `VITE_GOOGLE_MAPS_API_KEY`,
+· `yarn generate:api` (requires `../walky-backend/swagger.json`) · `generate:icons`/`generate:images`.
+Env: `VITE_API_BASE_URL` (must end in `/api`), `VITE_APP_NAME`, `VITE_ENV`, optional `VITE_GOOGLE_MAPS_API_KEY`,
 `VITE_SENTRY_DSN`.
 
-## Regras-chave
+## Key rules
 
-- ESLint: `no-console: error`; `@typescript-eslint/no-explicit-any: warn` (isento em `src/API/WalkyAPI.ts`,
-  `Api.ts`); `no-unused-vars` ignora prefixo `_`.
-- `WalkyAPI.ts` e cia são **gerados** — nunca editar à mão; regenerar via `generate:api`.
-- `VITE_API_BASE_URL` deve terminar em `/api` (o client remove `/api` para o cliente OpenAPI).
-- Pre-commit e CI bloqueiam por testids, a11y, testes.
-- `PermissionGuard`/`AuthGuard` retornam `null` durante `isLoading` (não é bug, evita flash).
-- Vercel: rewrite SPA em `vercel.json`; `BrowserRouter` em `main.tsx`.
+- ESLint: `no-console: error`; `@typescript-eslint/no-explicit-any: warn` (exempt in `src/API/WalkyAPI.ts`,
+  `Api.ts`); `no-unused-vars` ignores the `_` prefix.
+- `WalkyAPI.ts` and friends are **generated** — never hand-edit; regenerate via `generate:api`.
+- `VITE_API_BASE_URL` must end in `/api` (the client strips `/api` for the OpenAPI client).
+- Pre-commit and CI block on testids, a11y, tests.
+- `PermissionGuard`/`AuthGuard` return `null` during `isLoading` (not a bug, avoids flash).
+- Vercel: SPA rewrite in `vercel.json`; `BrowserRouter` in `main.tsx`.
 
-## Limitações / armadilhas
+## Limitations / pitfalls
 
-- **Sem refresh de token**: 401 sempre desloga (troubleshooting.md).
-- **`.env` versionado aponta para staging** — trocar para local em dev.
-- Dois sistemas de tema convivem (CoreUI `data-coreui-theme` + tokens V2 `--v2-*`); cores hardcoded não
-  herdam dark mode.
-- `generate:api` depende do backend clonado ao lado (`../walky-backend/swagger.json`) e atualizado.
-- `handlers.ts`/`test-utils.tsx` precisam acompanhar novos endpoints/providers, senão testes quebram
-  (request sem mock **falha** de propósito).
-- Pastas legadas (`components/`, `pages/`) ainda existem; não escrever código novo nelas.
-- README.md do repo é um tutorial genérico de CoreUI — o contexto real está em `AI_CONTEXT.md` e nestes docs.
-- Cobertura tem *ratchet* em `vitest.config.ts` (thresholds só sobem); baixar cobertura quebra o build.
+- **No token refresh**: a 401 always logs you out (troubleshooting.md).
+- **Env target**: your local `.env` (git-ignored) may point to staging; the committed `.env.example`
+  defaults to production — switch to local in dev.
+- Two theme systems coexist (CoreUI `data-coreui-theme` + V2 `--v2-*` tokens); hardcoded colors don't
+  inherit dark mode.
+- `generate:api` depends on the backend cloned alongside (`../walky-backend/swagger.json`) and kept current.
+- `handlers.ts`/`test-utils.tsx` must keep up with new endpoints/providers, or tests break
+  (an unmocked request **fails** on purpose).
+- Legacy folders (`components/`, `pages/`) still exist; don't write new code in them.
+- The repo's README.md is a generic CoreUI tutorial — the real context is in `AI_CONTEXT.md` and these docs.
+- Coverage has a *ratchet* in `vitest.config.ts` (thresholds only go up); lowering coverage breaks the build.

--- a/docs/ai-reference.md
+++ b/docs/ai-reference.md
@@ -1,0 +1,173 @@
+# AI Reference — walky-admin
+
+> Referência densa para LLMs. Mapa de diretórios, arquivos-chave (paths absolutos), convenções,
+> fluxos principais, regras e armadilhas. Fonte-de-verdade é o código; ver também
+> [conventions.md](./conventions.md) · [development.md](./development.md) · [troubleshooting.md](./troubleshooting.md).
+
+## Índice
+
+- [Identidade](#identidade)
+- [Stack](#stack)
+- [Mapa de diretórios](#mapa-de-diretórios)
+- [Arquivos-chave](#arquivos-chave)
+- [Fluxo de auth (login → guarda de rota)](#fluxo-de-auth-login--guarda-de-rota)
+- [Fluxo de RBAC (permissões)](#fluxo-de-rbac-permissões)
+- [Fluxo de dados (React Query + services + API gerada)](#fluxo-de-dados-react-query--services--api-gerada)
+- [Convenções obrigatórias](#convenções-obrigatórias)
+- [Comandos](#comandos)
+- [Regras-chave](#regras-chave)
+- [Limitações / armadilhas](#limitações--armadilhas)
+
+---
+
+## Identidade
+
+Painel administrativo do ecossistema **Walky** (rede social de campus). Público: `super_admin`,
+`school_admin`, `campus_admin`, `moderator`, `walky_internal`. Cliente do `walky-backend` (deriva tipos
+do Swagger). Deploy em Vercel. Repo em `/Volumes/SSDDEV/DEV_PROJETOS/walky-admin`.
+Contexto do ecossistema: `/Volumes/SSDDEV/DEV_PROJETOS/walky-admin/AI_CONTEXT.md`.
+
+## Stack
+
+React 19.1 · TypeScript 5.8 (strict, project references) · Vite 7 · React Router 7.6 · CoreUI 5.7 +
+React Bootstrap 2.10 · React Query 5.82 · Axios 1.10 · Recharts 3.4 + Three.js (Playground) · Vitest 4
++ RTL + MSW 2 · Sass. Node ≥ 20 (Vercel/`.nvmrc`: 22). Package manager efetivo: **yarn** (husky/CI).
+
+## Mapa de diretórios
+
+```
+/Volumes/SSDDEV/DEV_PROJETOS/walky-admin/
+├── src/
+│   ├── API/                 # cliente HTTP GERADO do Swagger (WalkyAPI.ts) + index.ts (Axios, interceptors)
+│   ├── components-v2/        # 53 componentes reutilizáveis (pasta = .tsx + .css + index.ts)
+│   │   └── index.ts          # barrel agregador
+│   ├── pages-v2/             # telas por feature (Admin, Campus, Dashboard, Events, Ideas, Spaces,
+│   │                         #  Moderation, Playground, LoginV2, RecoverPasswordV2, ForcePasswordChange)
+│   ├── layout-v2/            # LayoutV2 + SidebarV2 + TopbarV2
+│   ├── routes/v2Routes.tsx   # rotas lazy + PermissionGuard
+│   ├── contexts/             # School, Campus, Dashboard, DeactivatedUser, Theme
+│   ├── hooks/                # useAuth, usePermissions, useDebounce, useMediaQuery, useTheme, filtros
+│   ├── lib/                  # permissions.ts, queryClient.ts, logger.ts, utils/
+│   ├── services/             # userService, campusService, reportService, rolesService, ... (12)
+│   ├── styles-v2/            # design-tokens.css/.ts, theme-variables.css, global.css, ThemeComponents.css
+│   ├── theme.ts              # getTheme(isDark) → objeto de cores
+│   ├── test/                 # setup.ts, test-utils.tsx, server.ts, handlers.ts, factories.ts
+│   ├── App.tsx / main.tsx    # shell + montagem de providers
+│   ├── assets-v2/ types/     # assets novos, tipos
+│   └── (legado) components/ pages/ assets/  # descontinuando
+├── scripts/                  # check-test-ids.js, check-accessibility.js, generate-icons/images.cjs
+├── docs/                     # conventions/development/troubleshooting/ai-reference + TESTING.md
+├── .husky/pre-commit         # build → testids → a11y → lint-staged
+├── .github/workflows/        # code-quality.yml, test.yml
+├── eslint.config.js vite.config.ts vitest.config.ts vercel.json tsconfig*.json
+└── .env / .env.example
+```
+
+## Arquivos-chave
+
+| Path | Papel |
+|------|-------|
+| `src/main.tsx` | Monta providers: `QueryClientProvider` → `ThemeProvider` → `SchoolProvider` → `BrowserRouter` → `App`. Importa CSS CoreUI + tokens V2. |
+| `src/App.tsx` | Rotas públicas (`/login`, `/recover-password`, `/force-password-change`) + `AuthGuard` envolvendo `V2Routes`. Toaster (`react-hot-toast`). Alterna `body.dark-mode`. |
+| `src/routes/v2Routes.tsx` | Todas as rotas autenticadas, lazy, sob `LayoutV2`, cada uma com `PermissionGuard`. Providers `CampusProvider`/`DashboardProvider`. |
+| `src/API/index.ts` | Cria `apiClient` (do `WalkyAPI.ts`), remove `/api` do baseURL, interceptors: Bearer token, CSRF em não-GET, 401→logout, 403(`ACCOUNT_DEACTIVATED`)→modal. Exporta `apiClient`, `httpClient`, `API`. |
+| `src/API/WalkyAPI.ts` | Cliente Axios tipado GERADO (não editar). |
+| `src/lib/permissions.ts` | `permissionMatrix`, `hasPermission`, `routeResourceMap`, `roleHierarchy`, display-name maps. |
+| `src/hooks/useAuth.ts` | Lê `localStorage` (`token`,`user`), sincroniza entre abas (`storage`/`auth:user-updated`), `updateUser`. |
+| `src/hooks/usePermissions.ts` | `can/canRead/canUpdate/...`, flags `isSuperAdmin/isModerator/...`. |
+| `src/components-v2/AuthGuard/AuthGuard.tsx` | Redireciona não-autenticados p/ `/login`; `null` enquanto `isLoading`. |
+| `src/components-v2/PermissionGuard/PermissionGuard.tsx` | Guarda por `resource`+`action`; `fallback` `hidden`/`redirect`/node. HOC `withPermission`. |
+| `src/lib/queryClient.ts` | QueryClient (stale 5min, gc 10min, retry pula 4xx≠408) + `queryKeys` factory. |
+| `src/lib/logger.ts` | Wrapper de console (único autorizado); DEV-gated para debug/info. |
+| `src/styles-v2/design-tokens.css` | Tokens `--v2-*` + overrides dark sob `[data-coreui-theme="dark"]`/`[data-theme="dark"]`. |
+| `src/contexts/ThemeProvider.tsx` | Estado de tema, seta atributos no `<html>`, injeta `--app-*`. |
+| `src/contexts/SchoolContext.tsx` / `CampusContext.tsx` | Seleção multi-tenant (school/campus), persistida em `localStorage`. |
+| `src/test/test-utils.tsx` | `renderWithProviders` com stack real de providers + MemoryRouter. |
+| `src/test/handlers.ts` / `server.ts` / `factories.ts` | MSW default + server + builders. |
+| `scripts/check-test-ids.js` / `check-accessibility.js` | Gates de qualidade (pre-commit + CI). |
+
+## Fluxo de auth (login → guarda de rota)
+
+- Login (`src/pages-v2/LoginV2/`) grava `token` e `user` em `localStorage`; 2FA opcional; troca forçada
+  de senha em `/force-password-change`.
+- `useAuth` deriva `isAuthenticated` de `localStorage`; escuta `storage` (multi-aba) e evento custom
+  `auth:user-updated`. `updateUser(null)` faz logout local.
+- `AuthGuard` (em `App.tsx`, rota `/*`) barra não-autenticados; renderiza `null` durante `isLoading`
+  (evita flash de redirect no refresh).
+- Interceptors (`src/API/index.ts`): injetam `Authorization: Bearer <token>`; em **401** removem token
+  e navegam para `/login`. **Não há refresh automático de token neste repo.**
+- CSRF: em requests não-GET, lê cookie (`csrf_cookie_rr`/`XSRF-TOKEN`/…) e envia `X-CSRF-Token`/
+  `X-XSRF-Token`; Axios com `withCredentials: true`.
+- 403 com `code` `ACCOUNT_DEACTIVATED`/`USER_DEACTIVATED` → `triggerDeactivatedModal()`.
+
+## Fluxo de RBAC (permissões)
+
+- Roles: `super_admin`, `school_admin`, `campus_admin`, `moderator`, `walky_internal`.
+- Ações: `read`, `create`, `update`, `delete`, `export`, `manage`.
+- `permissionMatrix[role][resource] → ResourcePermission` (`src/lib/permissions.ts`).
+  Ex.: `super_admin.events_manager = readUpdateDeleteExport`; `moderator.active_students = noPermissions`,
+  mas `moderator.report_safety = readUpdateExport`; `walky_internal` é leitura-só (sem reports).
+- Rotas: `PermissionGuard resource=... fallback="redirect"` em `v2Routes.tsx`. `routeResourceMap`
+  mapeia path→resource (`canAccessRoute`); path não mapeado é liberado por default.
+- UI inline: `PermissionGuard fallback="hidden"` ou `withPermission`; ou `usePermissions().can(...)`.
+- Hierarquia de atribuição de role: `roleHierarchy` (super→school/campus/moderator; school→campus/
+  moderator; campus→moderator). Helpers `getAssignableRoles`, `canAssignRole(ByDisplayName)`.
+
+## Fluxo de dados (React Query + services + API gerada)
+
+```
+Componente (pages-v2)
+  └─ useQuery({ queryKey: [feature, ...filtros, school?._id, campus?._id], queryFn })
+       └─ service (src/services/*)  ── ou ──  apiClient.api.<método>() direto
+            └─ apiClient (src/API/index.ts)  # Axios + interceptors
+                 └─ WalkyAPI.ts (GERADO do swagger.json do backend)
+                      └─ walky-backend
+```
+
+- `queryKey` inclui **todos** os filtros + `selectedSchool?._id`/`selectedCampus?._id` (multi-tenant).
+- Buscas de texto passam por `useDebounce` (500 ms) antes da key.
+- Paginação: `placeholderData: keepPreviousData`.
+- Services normalizam a resposta (campos opcionais com `??`/`||`), logam via `logger`, `throw` no erro.
+- Contextos `School`/`Campus` selecionam o tenant; persistidos em `localStorage` (`selectedSchool`, etc.).
+
+## Convenções obrigatórias
+
+- Código novo em pastas **`-v2`** (components-v2/pages-v2/layout-v2/styles-v2/assets-v2). Legado em EOL.
+- Componente = pasta `Name/` com `Name.tsx` + `Name.css` (classes prefixadas `name-*`, sem CSS Modules) + `index.ts`.
+- `data-testid` em todo `<button>`/`<input>`/`<form>` de pages-v2/components-v2.
+- a11y WCAG 2.1 AA (alt, aria-label, labels, aria-checked/selected, focus styles).
+- Importar via barrel raiz (`../../../components-v2`), não do arquivo interno.
+- Server state via React Query; nunca `console.*` (usar `logger`).
+- Cores/spacing via tokens `--v2-*` para herdar dark mode.
+- Teste ao lado (`Foo.test.tsx`), render com `renderWithProviders`, MSW para rede.
+
+## Comandos
+
+`yarn dev` (5173) · `yarn build` (`tsc -b && vite build`) · `yarn test [--run]` · `yarn test:coverage`
+· `yarn check:testids` · `yarn check:a11y` · `yarn check:all` · `yarn lint` · `yarn type-check`
+· `yarn generate:api` (requer `../walky-backend/swagger.json`) · `generate:icons`/`generate:images`.
+Env: `VITE_API_BASE_URL` (terminar em `/api`), `VITE_APP_NAME`, `VITE_ENV`, opc. `VITE_GOOGLE_MAPS_API_KEY`,
+`VITE_SENTRY_DSN`.
+
+## Regras-chave
+
+- ESLint: `no-console: error`; `@typescript-eslint/no-explicit-any: warn` (isento em `src/API/WalkyAPI.ts`,
+  `Api.ts`); `no-unused-vars` ignora prefixo `_`.
+- `WalkyAPI.ts` e cia são **gerados** — nunca editar à mão; regenerar via `generate:api`.
+- `VITE_API_BASE_URL` deve terminar em `/api` (o client remove `/api` para o cliente OpenAPI).
+- Pre-commit e CI bloqueiam por testids, a11y, testes.
+- `PermissionGuard`/`AuthGuard` retornam `null` durante `isLoading` (não é bug, evita flash).
+- Vercel: rewrite SPA em `vercel.json`; `BrowserRouter` em `main.tsx`.
+
+## Limitações / armadilhas
+
+- **Sem refresh de token**: 401 sempre desloga (troubleshooting.md).
+- **`.env` versionado aponta para staging** — trocar para local em dev.
+- Dois sistemas de tema convivem (CoreUI `data-coreui-theme` + tokens V2 `--v2-*`); cores hardcoded não
+  herdam dark mode.
+- `generate:api` depende do backend clonado ao lado (`../walky-backend/swagger.json`) e atualizado.
+- `handlers.ts`/`test-utils.tsx` precisam acompanhar novos endpoints/providers, senão testes quebram
+  (request sem mock **falha** de propósito).
+- Pastas legadas (`components/`, `pages/`) ainda existem; não escrever código novo nelas.
+- README.md do repo é um tutorial genérico de CoreUI — o contexto real está em `AI_CONTEXT.md` e nestes docs.
+- Cobertura tem *ratchet* em `vitest.config.ts` (thresholds só sobem); baixar cobertura quebra o build.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,62 +1,61 @@
-# Walky Admin — Arquitetura
+# Walky Admin — Architecture
 
-> Como o painel é montado: React Router v7 com rotas lazy, Context + React Query para estado,
-> uma service layer sobre um cliente Axios gerado por Swagger, RBAC com `AuthGuard`/`PermissionGuard`
-> e o design system `layout-v2`. Este documento explica o **fluxo de dados** e o **porquê** de cada
-> decisão.
+> How the panel is assembled: React Router v7 with lazy routes, Context + React Query for state,
+> a service layer over an Axios client generated from Swagger, RBAC with `AuthGuard`/`PermissionGuard`,
+> and the `layout-v2` design system. This document explains the **data flow** and the **why** behind
+> each decision.
 
-## Índice
+## Table of Contents
 
-- [1. Visão macro](#1-visão-macro)
-- [2. Bootstrap e árvore de providers](#2-bootstrap-e-árvore-de-providers)
-- [3. Roteamento (React Router v7 + lazy)](#3-roteamento-react-router-v7--lazy)
-- [4. Camada de dados: Axios gerado + services + React Query](#4-camada-de-dados-axios-gerado--services--react-query)
-- [5. Autenticação e RBAC](#5-autenticação-e-rbac)
-- [6. Multi-tenant: School e Campus](#6-multi-tenant-school-e-campus)
-- [7. Tema e design tokens](#7-tema-e-design-tokens)
-- [8. Tipos gerados por Swagger](#8-tipos-gerados-por-swagger)
-- [9. Fluxo de dados ponta a ponta](#9-fluxo-de-dados-ponta-a-ponta)
-- [10. Decisões e trade-offs](#10-decisões-e-trade-offs)
+- [1. High-level overview](#1-high-level-overview)
+- [2. Bootstrap and provider tree](#2-bootstrap-and-provider-tree)
+- [3. Routing (React Router v7 + lazy)](#3-routing-react-router-v7--lazy)
+- [4. Data layer: generated Axios + services + React Query](#4-data-layer-generated-axios--services--react-query)
+- [5. Authentication and RBAC](#5-authentication-and-rbac)
+- [6. Multi-tenant: School and Campus](#6-multi-tenant-school-and-campus)
+- [7. Theme and design tokens](#7-theme-and-design-tokens)
+- [8. Swagger-generated types](#8-swagger-generated-types)
+- [9. End-to-end data flow](#9-end-to-end-data-flow)
+- [10. Decisions and trade-offs](#10-decisions-and-trade-offs)
 - [Cross-links](#cross-links)
 
 ---
 
-## 1. Visão macro
+## 1. High-level overview
 
 ```mermaid
 flowchart TB
     subgraph Browser["Browser (SPA)"]
         Router["React Router v7<br/>(lazy routes)"]
         Guards["AuthGuard + PermissionGuard"]
-        Pages["pages-v2/* (telas)"]
+        Pages["pages-v2/* (screens)"]
         Layout["layout-v2 (Sidebar + Topbar)"]
         Ctx["Contexts<br/>Theme · School · Campus · Dashboard · DeactivatedUser"]
         RQ["React Query cache"]
         Svc["services/* (userService, campusService, ...)"]
-        Client["apiClient (WalkyAPI.ts, gerado por Swagger)"]
+        Client["apiClient (WalkyAPI.ts, Swagger-generated)"]
         Axios["Axios + interceptors<br/>(token, CSRF, 401/403)"]
     end
-    BE["walky-backend<br/>API REST"]
+    BE["walky-backend<br/>REST API"]
 
     Router --> Guards --> Layout --> Pages
     Pages --> RQ --> Svc --> Client --> Axios --> BE
-    Pages -.lê/escreve.-> Ctx
-    Ctx -.injeta campus_id.-> Axios
+    Pages -.reads/writes.-> Ctx
+    Ctx -.selection read per query.-> Svc
 ```
 
-Princípios:
+Principles:
 
-- **SPA sem estado próprio de servidor** — todo dado vem do backend; React Query é o cache.
-- **Estado = Context + React Query** (sem Redux/Zustand). Context para UI/seleção; React Query para
-  dados remotos.
-- **Contrato tipado do backend** — o cliente HTTP é **gerado** do Swagger, não escrito à mão.
-- **Segurança em duas camadas** — `AuthGuard` (autenticado?) e `PermissionGuard` (pode este
-  recurso?), espelhando a matriz de `lib/permissions.ts`.
+- **SPA with no server state of its own** — all data comes from the backend; React Query is the cache.
+- **State = Context + React Query** (no Redux/Zustand). Context for UI/selection; React Query for
+  remote data.
+- **Typed backend contract** — the HTTP client is **generated** from Swagger, not hand-written.
+- **Two-layer security** — `AuthGuard` (authenticated?) and `PermissionGuard` (can access this
+  resource?), mirroring the matrix in `lib/permissions.ts`.
 
-## 2. Bootstrap e árvore de providers
+## 2. Bootstrap and provider tree
 
-Entry point [`src/main.tsx`](../src/main.tsx). A ordem dos providers importa (dependências de fora
-para dentro):
+Entry point [`src/main.tsx`](../src/main.tsx). Provider order matters (dependencies flow outside-in):
 
 ```mermaid
 flowchart TD
@@ -68,228 +67,233 @@ flowchart TD
     BR --> App["App"]
 ```
 
-- Importa os CSS globais: `@coreui/coreui/dist/css/coreui.min.css` + os `styles-v2/*.css`
+- Imports the global CSS: `@coreui/coreui/dist/css/coreui.min.css` + the `styles-v2/*.css` files
   (`ThemeComponents`, `design-tokens`, `global`).
-- `App.tsx` adiciona: `DeactivatedUserProvider`, o `<Toaster>` do react-hot-toast (estilizado à
-  identidade Walky) e o `<Suspense>` que envolve as rotas lazy.
-- `CampusProvider` e `DashboardProvider` ficam **dentro** de `V2Routes` (só existem na área
-  autenticada), enquanto `School`/`Theme` são globais (envolvem inclusive as telas públicas de
-  login).
+- `App.tsx` adds: `DeactivatedUserProvider`, the react-hot-toast `<Toaster>` (styled to the Walky
+  identity), and the `<Suspense>` that wraps the lazy routes.
+- `CampusProvider` and `DashboardProvider` live **inside** `V2Routes` (they only exist in the
+  authenticated area), whereas `School`/`Theme` are global (they wrap even the public login screens).
 
-## 3. Roteamento (React Router v7 + lazy)
+## 3. Routing (React Router v7 + lazy)
 
-Dois níveis de rotas.
+Two levels of routes.
 
-**Nível 1 — [`src/App.tsx`](../src/App.tsx):** separa rotas **públicas** das **protegidas**.
+**Level 1 — [`src/App.tsx`](../src/App.tsx):** separates **public** routes from **protected** ones.
 
-| Rota | Elemento |
+| Route | Element |
 |------|----------|
 | `/login` | `LoginV2` (lazy) |
 | `/recover-password`, `/auth/otp` | `RecoverPasswordV2` (lazy) |
 | `/force-password-change` | `ForcePasswordChange` (lazy) |
-| `/v2/*` | `V2RedirectHandler` — redireciona paths legados `/v2/...` para a raiz |
-| `/*` | `<AuthGuard><V2Routes/></AuthGuard>` — **tudo o mais exige autenticação** |
+| `/v2/*` | `V2RedirectHandler` — redirects legacy `/v2/...` paths to the root |
+| `/*` | `<AuthGuard><V2Routes/></AuthGuard>` — **everything else requires authentication** |
 
-**Nível 2 — [`src/routes/v2Routes.tsx`](../src/routes/v2Routes.tsx):** dentro de `<LayoutV2/>`
-(shell com sidebar/topbar via `<Outlet/>`), cada tela é **lazy-loaded** e envolvida por um
-`<PermissionGuard resource="..." fallback="redirect">`. O índice `/` redireciona para
+**Level 2 — [`src/routes/v2Routes.tsx`](../src/routes/v2Routes.tsx):** inside `<LayoutV2/>`
+(the shell with sidebar/topbar via `<Outlet/>`), each screen is **lazy-loaded** and wrapped in a
+`<PermissionGuard resource="..." fallback="redirect">`. The index `/` redirects to
 `dashboard/engagement`.
 
-**Por que lazy?** Code-splitting por rota: o bundle inicial carrega só o shell; cada página vira um
-chunk sob demanda (`React.lazy` + `Suspense`). Exports nomeados de barris (`pages-v2/Events`, etc.)
-são desembrulhados via `.then(m => ({ default: m.Name }))`. O Playground (Three.js, pesado) fica
-todo em chunks separados. Complementa o `manualChunks` do Vite (`react-vendor`, `coreui`, `charts`,
-`query`).
+**Why lazy?** Per-route code-splitting: the initial bundle loads only the shell; each page becomes an
+on-demand chunk (`React.lazy` + `Suspense`). Named barrel exports (`pages-v2/Events`, etc.) are
+unwrapped via `.then(m => ({ default: m.Name }))`. The Playground (Three.js, heavy) lives entirely in
+separate chunks. This complements Vite's `manualChunks` (`react-vendor`, `coreui`, `charts`, `query`).
 
-## 4. Camada de dados: Axios gerado + services + React Query
+## 4. Data layer: generated Axios + services + React Query
 
-Três anéis concêntricos.
+Three concentric rings.
 
-### 4.1 Cliente HTTP gerado — `src/API/`
+### 4.1 Generated HTTP client — `src/API/`
 
-- [`src/API/WalkyAPI.ts`](../src/API/WalkyAPI.ts) (~15k linhas) é **gerado** por
-  `swagger-typescript-api` a partir de `../walky-backend/swagger.json`. Contém a classe `Api` (todos
-  os endpoints tipados) e o `HttpClient` (wrapper Axios). É `// @ts-nocheck` — não editar à mão.
-- [`src/API/index.ts`](../src/API/index.ts) instancia e **configura** o cliente:
-  - `baseURL` = `VITE_API_BASE_URL` (default `http://localhost:8080/api`). Como o Swagger mistura
-    rotas com e sem prefixo `/api`, o código **remove o `/api` do baseURL** do `HttpClient`
-    (`baseURL.replace(/\/api\/?$/, "")`) para que rotas admin (`/api/admin/...`) e rotas legadas na
-    raiz (`/ambassadors`) funcionem.
-  - **Interceptor de request:** injeta `Authorization: Bearer <token>` (de `localStorage`) e, em
-    métodos não-GET, adiciona headers CSRF (`X-CSRF-Token` / `X-XSRF-Token`) lidos de cookies
-    (`csrf_cookie_rr`, `XSRF-TOKEN`, ...). `withCredentials: true` para enviar cookies.
-  - **Interceptor de response:** loga via `logger`; em **401** limpa o token e redireciona para
-    `/login`; em **403** com `code` `ACCOUNT_DEACTIVATED`/`USER_DEACTIVATED` dispara o modal de conta
-    desativada (`triggerDeactivatedModal`).
-  - Exporta `apiClient` (a instância de `Api`) — é o que os services usam.
-  - Também exporta um `API` axios "cru" com os mesmos interceptors (compatibilidade).
+- [`src/API/WalkyAPI.ts`](../src/API/WalkyAPI.ts) (~15k lines) is **generated** by
+  `swagger-typescript-api` from `../walky-backend/swagger.json`. It contains the `Api` class (all
+  typed endpoints) and the `HttpClient` (Axios wrapper). It is `// @ts-nocheck` — do not edit by hand.
+- [`src/API/index.ts`](../src/API/index.ts) instantiates and **configures** the client:
+  - `baseURL` = `VITE_API_BASE_URL` (default `http://localhost:8080/api`). Because Swagger mixes
+    routes with and without the `/api` prefix, the code **strips `/api` from the `HttpClient` baseURL**
+    (`baseURL.replace(/\/api\/?$/, "")`) so that admin routes (`/api/admin/...`) and legacy root
+    routes (`/ambassadors`) both work.
+  - **Request interceptor:** injects `Authorization: Bearer <token>` (from `localStorage`) and, on
+    non-GET methods, adds CSRF headers (`X-CSRF-Token` / `X-XSRF-Token`) read from cookies
+    (`csrf_cookie_rr`, `XSRF-TOKEN`, ...). `withCredentials: true` to send cookies.
+  - **Response interceptor:** logs via `logger`; on **401** it clears the token and redirects to
+    `/login`; on **403** with a `code` of `ACCOUNT_DEACTIVATED`/`USER_DEACTIVATED` it triggers the
+    deactivated-account modal (`triggerDeactivatedModal`).
+  - Exports `apiClient` (the `Api` instance) — this is what the services use.
+  - Also exports a "raw" `API` axios instance with the same interceptors (for compatibility).
 
 ### 4.2 Service layer — `src/services/`
 
 12 services (`userService`, `campusService`, `schoolService`, `ambassadorService`,
 `analyticsService`, `reportService`, `rolesService`, `interestService`, `placeService`,
-`placeTypeService`, `lockedUsersService`, `campusSyncService`). Padrão comum:
+`placeTypeService`, `lockedUsersService`, `campusSyncService`). Common pattern:
 
 ```ts
 import { apiClient } from "../API";
 export const userService = {
   getUsers: async (params) => {
     const response = await apiClient.api.adminUsersList({ ... });
-    return /* dados normalizados */;
+    return /* normalized data */;
   },
 };
 ```
 
-Todos importam o **`apiClient` gerado** (nenhum fala com o Axios cru), fazem try/catch, logam via
-`logger`, e **normalizam** a resposta para os tipos que as telas esperam (ex.: mapear `_id → id`,
-achatar paginação, unir tipos gerados com tipos de `src/types/`). É a fronteira entre "forma do
-backend" e "forma da UI".
+They all import the **generated `apiClient`** (none talk to the raw Axios), use try/catch, log via
+`logger`, and **normalize** the response into the types the screens expect (e.g. mapping `_id → id`,
+flattening pagination, merging generated types with types from `src/types/`). This is the boundary
+between "backend shape" and "UI shape".
 
-> **Por que uma service layer se o cliente já é tipado?** Para isolar as telas das idiossincrasias
-> do backend (nomes de endpoint gerados como `adminUsersList`, paginação inconsistente, `_id` vs
-> `id`) e concentrar a normalização em um só lugar.
+> **Why a service layer if the client is already typed?** To insulate the screens from the backend's
+> idiosyncrasies (generated endpoint names like `adminUsersList`, inconsistent pagination, `_id` vs
+> `id`) and to concentrate normalization in one place.
 
 ### 4.3 React Query — `src/lib/queryClient.ts`
 
-`QueryClient` com defaults:
+`QueryClient` with defaults:
 
-- `staleTime: 5min`, `gcTime: 10min` — dado admin muda devagar; evita refetch agressivo.
-- `retry` custom: **não** retenta 4xx (exceto 408); até 3 tentativas caso contrário. Mutations: 1
+- `staleTime: 5min`, `gcTime: 10min` — admin data changes slowly; avoids aggressive refetching.
+- Custom `retry`: does **not** retry 4xx (except 408); up to 3 attempts otherwise. Mutations: 1
   retry.
 - `refetchOnWindowFocus: false`.
 
-Há um `queryKeys` factory (campuses, campus, students, geofences, ambassadors, ...) para chaves
-consistentes.
+There is a `queryKeys` factory (campuses, campus, students, geofences, ambassadors, ...) for
+consistent keys.
 
-## 5. Autenticação e RBAC
+## 5. Authentication and RBAC
 
-### 5.1 Sessão
+### 5.1 Session
 
-Não há AuthProvider global de contexto; a sessão vive em **`localStorage`** (`token`, `user`) e é
-lida pelo hook [`src/hooks/useAuth.ts`](../src/hooks/useAuth.ts):
+There is no global auth context provider; the session lives in **`localStorage`** (`token`, `user`)
+and is read by the [`src/hooks/useAuth.ts`](../src/hooks/useAuth.ts) hook:
 
-- Lê `token` + `user` do storage; expõe `user`, `isAuthenticated`, `isLoading`, `hasRole`,
+- Reads `token` + `user` from storage; exposes `user`, `isAuthenticated`, `isLoading`, `hasRole`,
   `isSuperAdmin/isSchoolAdmin/isCampusAdmin`, `updateUser`.
-- **Sincroniza entre abas**: ouve o evento `storage` do browser e um evento custom
-  `auth:user-updated` (disparado por `updateUser`) — logout em uma aba reflete nas outras.
+- **Syncs across tabs**: listens to the browser `storage` event and a custom `auth:user-updated`
+  event (fired by `updateUser`) — logging out in one tab is reflected in the others.
 
-O **login** ([`pages-v2/LoginV2/LoginV2.tsx`](../src/pages-v2/LoginV2/LoginV2.tsx)) chama
-`apiClient.api.loginCreate({ email, password })` e trata:
+**Login** ([`pages-v2/LoginV2/LoginV2.tsx`](../src/pages-v2/LoginV2/LoginV2.tsx)) calls
+`apiClient.api.loginCreate({ email, password })` and handles:
 
 ```mermaid
 flowchart TD
     L["loginCreate(email,password)"] --> S{status?}
     S -->|"not_verified"| OTP["redirect /auth/otp?step=verify (2FA)"]
-    S -->|ok| R{role é admin?}
-    R -->|não| Err["erro: não é conta admin"]
-    R -->|sim| PC{require_password_change?}
-    PC -->|sim| FPC["redirect /force-password-change"]
-    PC -->|não| Store["salva token + user no localStorage"]
+    S -->|ok| R{role is admin?}
+    R -->|no| Err["error: not an admin account"]
+    R -->|yes| PC{require_password_change?}
+    PC -->|yes| FPC["redirect /force-password-change"]
+    PC -->|no| Store["save token + user in localStorage"]
     Store --> Home["window.location.href = '/' (reload)"]
-    S -->|USER_DEACTIVATED| Modal["modal conta desativada"]
+    S -->|USER_DEACTIVATED| Modal["deactivated-account modal"]
 ```
 
-O role precisa estar em uma allowlist de contas admin; a UI faz `window.location.href = "/"` para
-recarregar e reinicializar o estado de auth.
+The role must be in an allowlist of admin accounts; the UI does `window.location.href = "/"` to
+reload and reinitialize the auth state.
 
 ### 5.2 Guards
 
 ```mermaid
 flowchart LR
-    Route["Rota protegida"] --> AG{AuthGuard<br/>isLoading?}
+    Route["Protected route"] --> AG{AuthGuard<br/>isLoading?}
     AG -->|loading| Null["render null"]
-    AG -->|não autenticado| Login["Navigate /login (guarda origem em state.from)"]
-    AG -->|autenticado| PG{PermissionGuard<br/>can(resource, action)?}
+    AG -->|not authenticated| Login["Navigate /login (saves origin in state.from)"]
+    AG -->|authenticated| PG{PermissionGuard<br/>can(resource, action)?}
     PG -->|loading| Null2["render null"]
-    PG -->|sem permissão + fallback=redirect| Redir["Navigate /dashboard/engagement"]
-    PG -->|sem permissão + fallback=hidden| Hidden["render null"]
-    PG -->|permitido| Page["render tela"]
+    PG -->|no permission + fallback=redirect| Redir["Navigate /dashboard/engagement"]
+    PG -->|no permission + fallback=hidden| Hidden["render null"]
+    PG -->|allowed| Page["render screen"]
 ```
 
-- [`AuthGuard`](../src/components-v2/AuthGuard/AuthGuard.tsx): envolve `V2Routes` (todo o app
-  autenticado). Aguarda `isLoading`, senão redireciona a `/login` preservando `location` em
+- [`AuthGuard`](../src/components-v2/AuthGuard/AuthGuard.tsx): wraps `V2Routes` (the entire
+  authenticated app). Waits on `isLoading`, otherwise redirects to `/login`, preserving `location` in
   `state.from`.
 - [`PermissionGuard`](../src/components-v2/PermissionGuard/PermissionGuard.tsx): props `resource`,
   `action` (default `read`), `fallback` (`'hidden' | 'redirect' | ReactNode`, default `hidden`),
-  `redirectTo` (default `/dashboard/engagement`). Usa `usePermissions().can(...)`. Espera o auth
-  carregar antes de decidir (evita loop de redirect no refresh). Também há um HOC `withPermission()`.
-  - **Como guarda de rota** (em `v2Routes.tsx`): `fallback="redirect"`.
-  - **Como guarda inline** (esconder botão de export/editar): `fallback="hidden"` (default).
+  `redirectTo` (default `/dashboard/engagement`). Uses `usePermissions().can(...)`. Waits for auth to
+  load before deciding (avoids a redirect loop on refresh). There is also a `withPermission()` HOC.
+  - **As a route guard** (in `v2Routes.tsx`): `fallback="redirect"`.
+  - **As an inline guard** (hiding an export/edit button): `fallback="hidden"` (default).
 
-### 5.3 Matriz de permissões
+### 5.3 Permission matrix
 
-[`src/lib/permissions.ts`](../src/lib/permissions.ts) é a fonte da verdade do RBAC no cliente:
+[`src/lib/permissions.ts`](../src/lib/permissions.ts) is the source of truth for client-side RBAC:
 
-- `permissionMatrix: Record<RoleName, Record<PermissionResource, ResourcePermission>>` — para cada
-  um dos 5 roles e ~24 recursos, um objeto com flags `read/create/update/delete/export/manage`.
+- `permissionMatrix: Record<RoleName, Record<PermissionResource, ResourcePermission>>` — for each of
+  the 5 roles and ~24 resources, an object with `read/create/update/delete/export/manage` flags.
 - Helpers: `getPermissions`, `hasPermission`, `canAccessRoute` (+ `routeResourceMap`),
-  `getAssignableRoles`/`canAssignRole` (hierarquia de atribuição), `roleDisplayNameMap`.
-- [`usePermissions`](../src/hooks/usePermissions.ts) expõe `can/canRead/canCreate/canUpdate/
-  canDelete/canExport/canManage/canAccessPath` + flags `isSuperAdmin/...`, memoizados por `userRole`.
+  `getAssignableRoles`/`canAssignRole` (assignment hierarchy), `roleDisplayNameMap`.
+- [`usePermissions`](../src/hooks/usePermissions.ts) exposes `can/canRead/canCreate/canUpdate/
+  canDelete/canExport/canManage/canAccessPath` + `isSuperAdmin/...` flags, memoized by `userRole`.
 
-A **sidebar** ([`layout-v2/SidebarV2`](../src/layout-v2/SidebarV2/SidebarV2.tsx)) usa `canRead(resource)`
-para **filtrar itens de menu**: item sem permissão é removido; submenu vazio some junto do pai.
-Assim, o usuário só vê o que pode acessar — a UI, a rota e a API concordam com a mesma matriz.
+The **sidebar** ([`layout-v2/SidebarV2`](../src/layout-v2/SidebarV2/SidebarV2.tsx)) uses
+`canRead(resource)` to **filter menu items**: an item without permission is removed; an empty submenu
+disappears along with its parent. This way the user only sees what they can access — the UI, the route,
+and the API all agree on the same matrix.
 
-> **Defesa em profundidade:** o RBAC do cliente é UX (esconder/guardar), **não** segurança final. O
-> backend valida cada request (JWT + permissões). O cliente evita mostrar o que não deve, mas a
-> autoridade é do servidor.
+> **Defense in depth:** client-side RBAC is UX (hide/guard), **not** final security. The backend
+> validates every request (JWT + permissions). The client avoids showing what it shouldn't, but the
+> authority belongs to the server.
 
-## 6. Multi-tenant: School e Campus
+## 6. Multi-tenant: School and Campus
 
-A plataforma é multi-tenant por **escola** e **campus**. Dois contexts (persistidos em
-`localStorage`) guardam a seleção atual:
+The platform is multi-tenant by **school** and **campus**. Two contexts (persisted to `localStorage`)
+hold the current selection:
 
 - [`SchoolContext`](../src/contexts/SchoolContext.tsx): `selectedSchool`, `availableSchools`,
-  `setSelectedSchool` (persiste `selectedSchool`), `clearSchoolSelection`.
+  `setSelectedSchool` (persists `selectedSchool`), `clearSchoolSelection`.
 - [`CampusContext`](../src/contexts/CampusContext.tsx): `selectedCampus`, `availableCampuses`,
-  `setSelectedCampus` (persiste `selectedCampus`), `clearCampusSelection`.
+  `setSelectedCampus` (persists `selectedCampus`), `clearCampusSelection`.
 
-Os seletores ficam na **Topbar** ([`layout-v2/TopbarV2`](../src/layout-v2/TopbarV2/TopbarV2.tsx)):
-super_admin escolhe escola/campus; para school_admin/campus_admin a seleção é derivada do seu
+The selectors live in the **Topbar** ([`layout-v2/TopbarV2`](../src/layout-v2/TopbarV2/TopbarV2.tsx)):
+super_admin picks the school/campus; for school_admin/campus_admin the selection is derived from their
 `school_id`/`campus_id`.
 
-**Como o campus entra nas requests:** o hook
-[`useCampusFilter`](../src/hooks/useCampusFilter.ts) registra um **interceptor de request** que
-injeta `campus_id` automaticamente — em `params` para GET e no corpo para POST/PUT/PATCH — sempre que
-há campus selecionado, e faz `eject` do interceptor ao trocar de campus/desmontar. Assim as telas
-não precisam passar `campus_id` manualmente.
+**How the campus reaches the requests:** each query reads the selected campus/school from these
+contexts and passes `campus_id`/`schoolId` **explicitly** as a parameter to the service call.
 
-## 7. Tema e design tokens
+> **Caveat — the filter hooks are not wired up.** The hooks
+> [`useCampusFilter`](../src/hooks/useCampusFilter.ts) and
+> [`useSchoolFilter`](../src/hooks/useSchoolFilter.ts) are **defined but never invoked**: they were
+> designed to register an Axios request interceptor that would automatically inject `campus_id`/
+> `schoolId` (into `params` for GET and into the body for POST/PUT/PATCH). That mechanism is **not
+> active**. In practice, the effective multi-tenant filter is applied by **passing `campus_id`/
+> `schoolId` explicitly per query**, not through a global interceptor.
 
-Sistema de tema **dual** (CoreUI + tokens V2), em [`ThemeProvider`](../src/contexts/ThemeProvider.tsx)
-+ [`ThemeContext`](../src/contexts/ThemeContext.ts) + [`src/theme.ts`](../src/theme.ts):
+## 7. Theme and design tokens
 
-- Estado `isDarkMode` inicializado de `localStorage` (`theme`) ou `prefers-color-scheme`.
-- Ao alternar, aplica no `<html>` `data-coreui-theme` (para o CoreUI) **e** `data-theme`, injeta as
-  cores como CSS vars `--app-*`, e toggla classes no `<body>` (`dark-theme`, e `dark-mode` via
+A **dual** theme system (CoreUI + V2 tokens), in
+[`ThemeProvider`](../src/contexts/ThemeProvider.tsx) + [`ThemeContext`](../src/contexts/ThemeContext.ts)
++ [`src/theme.ts`](../src/theme.ts):
+
+- `isDarkMode` state initialized from `localStorage` (`theme`) or `prefers-color-scheme`.
+- On toggle, it sets `data-coreui-theme` (for CoreUI) **and** `data-theme` on `<html>`, injects the
+  colors as `--app-*` CSS vars, and toggles classes on `<body>` (`dark-theme`, and `dark-mode` via
   `App.tsx`).
-- Tokens de design ficam em `src/styles-v2/`: `design-tokens.css`/`.ts` (auto-gerados do Figma),
-  `theme-variables.css`, `ThemeComponents.css`, `global.css`. A versão `.ts` (`design-tokens.ts`)
-  exporta `spacing`, `cornerRadius`, `colors`, etc., para uso em JS.
+- Design tokens live in `src/styles-v2/`: `design-tokens.css`/`.ts` (auto-generated from Figma),
+  `theme-variables.css`, `ThemeComponents.css`, `global.css`. The `.ts` version (`design-tokens.ts`)
+  exports `spacing`, `cornerRadius`, `colors`, etc., for use in JS.
 
-## 8. Tipos gerados por Swagger
+## 8. Swagger-generated types
 
 ```mermaid
 flowchart LR
-    SW["../walky-backend/swagger.json"] -->|"npm run generate:api"| GEN["src/API/WalkyAPI.ts + data-contracts.ts (gerados)"]
+    SW["../walky-backend/swagger.json"] -->|"npm run generate:api"| GEN["src/API/WalkyAPI.ts + data-contracts.ts (generated)"]
     GEN --> SVC["services/*"]
-    HT["src/types/* (hand-written: extensões, unions, helpers)"] --> SVC
+    HT["src/types/* (hand-written: extensions, unions, helpers)"] --> SVC
     SVC --> Pages["pages-v2/*"]
 ```
 
-- **Gerado:** `src/API/WalkyAPI.ts` (+ arquivos irmãos `Api.ts`, `data-contracts.ts`, `Admin.ts`,
+- **Generated:** `src/API/WalkyAPI.ts` (+ sibling files `Api.ts`, `data-contracts.ts`, `Admin.ts`,
   `Users.ts`, `Auth.ts`, `Analytics.ts`, `Ambassadors.ts`, `Audit.ts`, `Age.ts`, `http-client.ts`) —
-  todos com o header "GENERATED VIA SWAGGER-TYPESCRIPT-API".
+  all carrying the "GENERATED VIA SWAGGER-TYPESCRIPT-API" header.
 - **Hand-written:** `src/types/*` (`ambassador`, `analytics`, `api`, `campus`, `place`, `placeType`,
-  `report`, `role`) — extensões/uniões específicas da UI que os services combinam com os tipos
-  gerados (ex.: `UserWithRoles extends Omit<User, ...>` em `userService.ts`).
+  `report`, `role`) — UI-specific extensions/unions that the services merge with the generated types
+  (e.g. `UserWithRoles extends Omit<User, ...>` in `userService.ts`).
 
-Regenerar após mudança de contrato no backend: `npm run generate:api`.
+Regenerate after a backend contract change: `npm run generate:api`.
 
-## 9. Fluxo de dados ponta a ponta
+## 9. End-to-end data flow
 
-Exemplo: **abrir "Active Students" e exportar**.
+Example: **open "Active Students" and export**.
 
 ```mermaid
 sequenceDiagram
@@ -302,40 +306,41 @@ sequenceDiagram
     participant I as Axios interceptors
     participant B as walky-backend
 
-    U->>R: navega /manage-students/active
-    R->>R: can('active_students','read')? sim
-    R->>P: monta a tela
+    U->>R: navigate /manage-students/active
+    R->>R: can('active_students','read')? yes
+    R->>P: mount the screen
     P->>Q: useQuery(students)
-    Q->>S: userService.getUsers({page,limit,search})
+    Q->>S: userService.getUsers({page,limit,search,campus_id})
+    Note over Q,S: campus_id is passed explicitly per query<br/>(useCampusFilter is defined but not wired up)
     S->>C: apiClient.api.adminUsersList(...)
-    C->>I: request → + Bearer token, + campus_id (useCampusFilter), + CSRF
+    C->>I: request → + Bearer token, + CSRF
     I->>B: GET /api/admin/users?...&campus_id=...
     B-->>I: 200 { users, pagination }
-    I-->>Q: normaliza → cacheia (staleTime 5min)
-    Q-->>P: dados
-    U->>P: clica "Export" (só visível se can('active_students','export'))
-    P->>P: gera CSV/PDF (ExportButton / html2pdf)
+    I-->>Q: normalize → cache (staleTime 5min)
+    Q-->>P: data
+    U->>P: clicks "Export" (only visible if can('active_students','export'))
+    P->>P: generate CSV/PDF (ExportButton / html2pdf)
 ```
 
-Erros: 401 → interceptor limpa token e vai a `/login`; 403 `ACCOUNT_DEACTIVATED` → modal;
-outros 4xx → React Query não retenta.
+Errors: 401 → interceptor clears the token and goes to `/login`; 403 `ACCOUNT_DEACTIVATED` → modal;
+other 4xx → React Query does not retry.
 
-## 10. Decisões e trade-offs
+## 10. Decisions and trade-offs
 
-| Decisão | Porquê | Trade-off |
+| Decision | Why | Trade-off |
 |---------|--------|-----------|
-| **Cliente HTTP gerado por Swagger** | Contrato único com o backend; menos drift; tipos grátis | Arquivo enorme `// @ts-nocheck`; precisa regenerar quando o backend muda |
-| **Service layer sobre o cliente gerado** | Isola telas de nomes/formatos do backend; centraliza normalização (`_id→id`, paginação) | Camada extra de indireção |
-| **Context + React Query (sem Redux/Zustand)** | Estado remoto no React Query; UI/seleção em Context simples; menos boilerplate | Sem store centralizada; seleção multi-tenant espalhada em contexts |
-| **Sessão em localStorage + sync por eventos** | Simples; funciona entre abas; sobrevive a reload | Suscetível a XSS (mitigado por CSP/backend); não é httpOnly |
-| **RBAC no cliente (matriz em `permissions.ts`)** | UX: esconder o que o usuário não pode; guardar rotas | Não é segurança — o backend precisa reforçar tudo |
-| **Rotas lazy + manualChunks** | Bundle inicial pequeno; Playground/Three.js isolados | Suspense/flash de loading por rota |
-| **`campus_id` via interceptor (`useCampusFilter`)** | Multi-tenant transparente; telas não passam campus manualmente | Interceptor global com efeito "mágico"; cuidado ao depurar |
-| **Sufixo `-v2` na camada de UI** | Redesign completo da UI preservando a arquitetura (ver folder-structure) | Coexistência de nomes; `assets/` legado ao lado de `assets-v2/` |
+| **Swagger-generated HTTP client** | Single contract with the backend; less drift; free types | Huge `// @ts-nocheck` file; must be regenerated when the backend changes |
+| **Service layer over the generated client** | Insulates screens from backend names/formats; centralizes normalization (`_id→id`, pagination) | Extra layer of indirection |
+| **Context + React Query (no Redux/Zustand)** | Remote state in React Query; UI/selection in simple Context; less boilerplate | No centralized store; multi-tenant selection spread across contexts |
+| **Session in localStorage + event-based sync** | Simple; works across tabs; survives a reload | Susceptible to XSS (mitigated by CSP/backend); not httpOnly |
+| **Client-side RBAC (matrix in `permissions.ts`)** | UX: hide what the user can't do; guard routes | Not security — the backend must enforce everything |
+| **Lazy routes + manualChunks** | Small initial bundle; Playground/Three.js isolated | Suspense/loading flash per route |
+| **`campus_id` passed explicitly per query** | Multi-tenant filtering that is easy to trace; no hidden global interceptor (the `useCampusFilter`/`useSchoolFilter` interceptor hooks exist but are not wired up) | Each query must remember to pass `campus_id`/`schoolId` |
+| **`-v2` suffix on the UI layer** | Complete UI redesign while preserving the architecture (see folder-structure) | Coexisting names; legacy `assets/` alongside `assets-v2/` |
 
 ---
 
 ## Cross-links
 
-- [Visão geral](./overview.md) — propósito, público, stack.
-- [Estrutura de pastas](./folder-structure.md) — cada diretório e o sufixo `-v2`.
+- [Overview](./overview.md) — purpose, audience, stack.
+- [Folder structure](./folder-structure.md) — each directory and the `-v2` suffix.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,341 @@
+# Walky Admin — Arquitetura
+
+> Como o painel é montado: React Router v7 com rotas lazy, Context + React Query para estado,
+> uma service layer sobre um cliente Axios gerado por Swagger, RBAC com `AuthGuard`/`PermissionGuard`
+> e o design system `layout-v2`. Este documento explica o **fluxo de dados** e o **porquê** de cada
+> decisão.
+
+## Índice
+
+- [1. Visão macro](#1-visão-macro)
+- [2. Bootstrap e árvore de providers](#2-bootstrap-e-árvore-de-providers)
+- [3. Roteamento (React Router v7 + lazy)](#3-roteamento-react-router-v7--lazy)
+- [4. Camada de dados: Axios gerado + services + React Query](#4-camada-de-dados-axios-gerado--services--react-query)
+- [5. Autenticação e RBAC](#5-autenticação-e-rbac)
+- [6. Multi-tenant: School e Campus](#6-multi-tenant-school-e-campus)
+- [7. Tema e design tokens](#7-tema-e-design-tokens)
+- [8. Tipos gerados por Swagger](#8-tipos-gerados-por-swagger)
+- [9. Fluxo de dados ponta a ponta](#9-fluxo-de-dados-ponta-a-ponta)
+- [10. Decisões e trade-offs](#10-decisões-e-trade-offs)
+- [Cross-links](#cross-links)
+
+---
+
+## 1. Visão macro
+
+```mermaid
+flowchart TB
+    subgraph Browser["Browser (SPA)"]
+        Router["React Router v7<br/>(lazy routes)"]
+        Guards["AuthGuard + PermissionGuard"]
+        Pages["pages-v2/* (telas)"]
+        Layout["layout-v2 (Sidebar + Topbar)"]
+        Ctx["Contexts<br/>Theme · School · Campus · Dashboard · DeactivatedUser"]
+        RQ["React Query cache"]
+        Svc["services/* (userService, campusService, ...)"]
+        Client["apiClient (WalkyAPI.ts, gerado por Swagger)"]
+        Axios["Axios + interceptors<br/>(token, CSRF, 401/403)"]
+    end
+    BE["walky-backend<br/>API REST"]
+
+    Router --> Guards --> Layout --> Pages
+    Pages --> RQ --> Svc --> Client --> Axios --> BE
+    Pages -.lê/escreve.-> Ctx
+    Ctx -.injeta campus_id.-> Axios
+```
+
+Princípios:
+
+- **SPA sem estado próprio de servidor** — todo dado vem do backend; React Query é o cache.
+- **Estado = Context + React Query** (sem Redux/Zustand). Context para UI/seleção; React Query para
+  dados remotos.
+- **Contrato tipado do backend** — o cliente HTTP é **gerado** do Swagger, não escrito à mão.
+- **Segurança em duas camadas** — `AuthGuard` (autenticado?) e `PermissionGuard` (pode este
+  recurso?), espelhando a matriz de `lib/permissions.ts`.
+
+## 2. Bootstrap e árvore de providers
+
+Entry point [`src/main.tsx`](../src/main.tsx). A ordem dos providers importa (dependências de fora
+para dentro):
+
+```mermaid
+flowchart TD
+    Root["createRoot"] --> Strict["StrictMode"]
+    Strict --> QCP["QueryClientProvider (queryClient)"]
+    QCP --> TP["ThemeProvider"]
+    TP --> SP["SchoolProvider"]
+    SP --> BR["BrowserRouter"]
+    BR --> App["App"]
+```
+
+- Importa os CSS globais: `@coreui/coreui/dist/css/coreui.min.css` + os `styles-v2/*.css`
+  (`ThemeComponents`, `design-tokens`, `global`).
+- `App.tsx` adiciona: `DeactivatedUserProvider`, o `<Toaster>` do react-hot-toast (estilizado à
+  identidade Walky) e o `<Suspense>` que envolve as rotas lazy.
+- `CampusProvider` e `DashboardProvider` ficam **dentro** de `V2Routes` (só existem na área
+  autenticada), enquanto `School`/`Theme` são globais (envolvem inclusive as telas públicas de
+  login).
+
+## 3. Roteamento (React Router v7 + lazy)
+
+Dois níveis de rotas.
+
+**Nível 1 — [`src/App.tsx`](../src/App.tsx):** separa rotas **públicas** das **protegidas**.
+
+| Rota | Elemento |
+|------|----------|
+| `/login` | `LoginV2` (lazy) |
+| `/recover-password`, `/auth/otp` | `RecoverPasswordV2` (lazy) |
+| `/force-password-change` | `ForcePasswordChange` (lazy) |
+| `/v2/*` | `V2RedirectHandler` — redireciona paths legados `/v2/...` para a raiz |
+| `/*` | `<AuthGuard><V2Routes/></AuthGuard>` — **tudo o mais exige autenticação** |
+
+**Nível 2 — [`src/routes/v2Routes.tsx`](../src/routes/v2Routes.tsx):** dentro de `<LayoutV2/>`
+(shell com sidebar/topbar via `<Outlet/>`), cada tela é **lazy-loaded** e envolvida por um
+`<PermissionGuard resource="..." fallback="redirect">`. O índice `/` redireciona para
+`dashboard/engagement`.
+
+**Por que lazy?** Code-splitting por rota: o bundle inicial carrega só o shell; cada página vira um
+chunk sob demanda (`React.lazy` + `Suspense`). Exports nomeados de barris (`pages-v2/Events`, etc.)
+são desembrulhados via `.then(m => ({ default: m.Name }))`. O Playground (Three.js, pesado) fica
+todo em chunks separados. Complementa o `manualChunks` do Vite (`react-vendor`, `coreui`, `charts`,
+`query`).
+
+## 4. Camada de dados: Axios gerado + services + React Query
+
+Três anéis concêntricos.
+
+### 4.1 Cliente HTTP gerado — `src/API/`
+
+- [`src/API/WalkyAPI.ts`](../src/API/WalkyAPI.ts) (~15k linhas) é **gerado** por
+  `swagger-typescript-api` a partir de `../walky-backend/swagger.json`. Contém a classe `Api` (todos
+  os endpoints tipados) e o `HttpClient` (wrapper Axios). É `// @ts-nocheck` — não editar à mão.
+- [`src/API/index.ts`](../src/API/index.ts) instancia e **configura** o cliente:
+  - `baseURL` = `VITE_API_BASE_URL` (default `http://localhost:8080/api`). Como o Swagger mistura
+    rotas com e sem prefixo `/api`, o código **remove o `/api` do baseURL** do `HttpClient`
+    (`baseURL.replace(/\/api\/?$/, "")`) para que rotas admin (`/api/admin/...`) e rotas legadas na
+    raiz (`/ambassadors`) funcionem.
+  - **Interceptor de request:** injeta `Authorization: Bearer <token>` (de `localStorage`) e, em
+    métodos não-GET, adiciona headers CSRF (`X-CSRF-Token` / `X-XSRF-Token`) lidos de cookies
+    (`csrf_cookie_rr`, `XSRF-TOKEN`, ...). `withCredentials: true` para enviar cookies.
+  - **Interceptor de response:** loga via `logger`; em **401** limpa o token e redireciona para
+    `/login`; em **403** com `code` `ACCOUNT_DEACTIVATED`/`USER_DEACTIVATED` dispara o modal de conta
+    desativada (`triggerDeactivatedModal`).
+  - Exporta `apiClient` (a instância de `Api`) — é o que os services usam.
+  - Também exporta um `API` axios "cru" com os mesmos interceptors (compatibilidade).
+
+### 4.2 Service layer — `src/services/`
+
+12 services (`userService`, `campusService`, `schoolService`, `ambassadorService`,
+`analyticsService`, `reportService`, `rolesService`, `interestService`, `placeService`,
+`placeTypeService`, `lockedUsersService`, `campusSyncService`). Padrão comum:
+
+```ts
+import { apiClient } from "../API";
+export const userService = {
+  getUsers: async (params) => {
+    const response = await apiClient.api.adminUsersList({ ... });
+    return /* dados normalizados */;
+  },
+};
+```
+
+Todos importam o **`apiClient` gerado** (nenhum fala com o Axios cru), fazem try/catch, logam via
+`logger`, e **normalizam** a resposta para os tipos que as telas esperam (ex.: mapear `_id → id`,
+achatar paginação, unir tipos gerados com tipos de `src/types/`). É a fronteira entre "forma do
+backend" e "forma da UI".
+
+> **Por que uma service layer se o cliente já é tipado?** Para isolar as telas das idiossincrasias
+> do backend (nomes de endpoint gerados como `adminUsersList`, paginação inconsistente, `_id` vs
+> `id`) e concentrar a normalização em um só lugar.
+
+### 4.3 React Query — `src/lib/queryClient.ts`
+
+`QueryClient` com defaults:
+
+- `staleTime: 5min`, `gcTime: 10min` — dado admin muda devagar; evita refetch agressivo.
+- `retry` custom: **não** retenta 4xx (exceto 408); até 3 tentativas caso contrário. Mutations: 1
+  retry.
+- `refetchOnWindowFocus: false`.
+
+Há um `queryKeys` factory (campuses, campus, students, geofences, ambassadors, ...) para chaves
+consistentes.
+
+## 5. Autenticação e RBAC
+
+### 5.1 Sessão
+
+Não há AuthProvider global de contexto; a sessão vive em **`localStorage`** (`token`, `user`) e é
+lida pelo hook [`src/hooks/useAuth.ts`](../src/hooks/useAuth.ts):
+
+- Lê `token` + `user` do storage; expõe `user`, `isAuthenticated`, `isLoading`, `hasRole`,
+  `isSuperAdmin/isSchoolAdmin/isCampusAdmin`, `updateUser`.
+- **Sincroniza entre abas**: ouve o evento `storage` do browser e um evento custom
+  `auth:user-updated` (disparado por `updateUser`) — logout em uma aba reflete nas outras.
+
+O **login** ([`pages-v2/LoginV2/LoginV2.tsx`](../src/pages-v2/LoginV2/LoginV2.tsx)) chama
+`apiClient.api.loginCreate({ email, password })` e trata:
+
+```mermaid
+flowchart TD
+    L["loginCreate(email,password)"] --> S{status?}
+    S -->|"not_verified"| OTP["redirect /auth/otp?step=verify (2FA)"]
+    S -->|ok| R{role é admin?}
+    R -->|não| Err["erro: não é conta admin"]
+    R -->|sim| PC{require_password_change?}
+    PC -->|sim| FPC["redirect /force-password-change"]
+    PC -->|não| Store["salva token + user no localStorage"]
+    Store --> Home["window.location.href = '/' (reload)"]
+    S -->|USER_DEACTIVATED| Modal["modal conta desativada"]
+```
+
+O role precisa estar em uma allowlist de contas admin; a UI faz `window.location.href = "/"` para
+recarregar e reinicializar o estado de auth.
+
+### 5.2 Guards
+
+```mermaid
+flowchart LR
+    Route["Rota protegida"] --> AG{AuthGuard<br/>isLoading?}
+    AG -->|loading| Null["render null"]
+    AG -->|não autenticado| Login["Navigate /login (guarda origem em state.from)"]
+    AG -->|autenticado| PG{PermissionGuard<br/>can(resource, action)?}
+    PG -->|loading| Null2["render null"]
+    PG -->|sem permissão + fallback=redirect| Redir["Navigate /dashboard/engagement"]
+    PG -->|sem permissão + fallback=hidden| Hidden["render null"]
+    PG -->|permitido| Page["render tela"]
+```
+
+- [`AuthGuard`](../src/components-v2/AuthGuard/AuthGuard.tsx): envolve `V2Routes` (todo o app
+  autenticado). Aguarda `isLoading`, senão redireciona a `/login` preservando `location` em
+  `state.from`.
+- [`PermissionGuard`](../src/components-v2/PermissionGuard/PermissionGuard.tsx): props `resource`,
+  `action` (default `read`), `fallback` (`'hidden' | 'redirect' | ReactNode`, default `hidden`),
+  `redirectTo` (default `/dashboard/engagement`). Usa `usePermissions().can(...)`. Espera o auth
+  carregar antes de decidir (evita loop de redirect no refresh). Também há um HOC `withPermission()`.
+  - **Como guarda de rota** (em `v2Routes.tsx`): `fallback="redirect"`.
+  - **Como guarda inline** (esconder botão de export/editar): `fallback="hidden"` (default).
+
+### 5.3 Matriz de permissões
+
+[`src/lib/permissions.ts`](../src/lib/permissions.ts) é a fonte da verdade do RBAC no cliente:
+
+- `permissionMatrix: Record<RoleName, Record<PermissionResource, ResourcePermission>>` — para cada
+  um dos 5 roles e ~24 recursos, um objeto com flags `read/create/update/delete/export/manage`.
+- Helpers: `getPermissions`, `hasPermission`, `canAccessRoute` (+ `routeResourceMap`),
+  `getAssignableRoles`/`canAssignRole` (hierarquia de atribuição), `roleDisplayNameMap`.
+- [`usePermissions`](../src/hooks/usePermissions.ts) expõe `can/canRead/canCreate/canUpdate/
+  canDelete/canExport/canManage/canAccessPath` + flags `isSuperAdmin/...`, memoizados por `userRole`.
+
+A **sidebar** ([`layout-v2/SidebarV2`](../src/layout-v2/SidebarV2/SidebarV2.tsx)) usa `canRead(resource)`
+para **filtrar itens de menu**: item sem permissão é removido; submenu vazio some junto do pai.
+Assim, o usuário só vê o que pode acessar — a UI, a rota e a API concordam com a mesma matriz.
+
+> **Defesa em profundidade:** o RBAC do cliente é UX (esconder/guardar), **não** segurança final. O
+> backend valida cada request (JWT + permissões). O cliente evita mostrar o que não deve, mas a
+> autoridade é do servidor.
+
+## 6. Multi-tenant: School e Campus
+
+A plataforma é multi-tenant por **escola** e **campus**. Dois contexts (persistidos em
+`localStorage`) guardam a seleção atual:
+
+- [`SchoolContext`](../src/contexts/SchoolContext.tsx): `selectedSchool`, `availableSchools`,
+  `setSelectedSchool` (persiste `selectedSchool`), `clearSchoolSelection`.
+- [`CampusContext`](../src/contexts/CampusContext.tsx): `selectedCampus`, `availableCampuses`,
+  `setSelectedCampus` (persiste `selectedCampus`), `clearCampusSelection`.
+
+Os seletores ficam na **Topbar** ([`layout-v2/TopbarV2`](../src/layout-v2/TopbarV2/TopbarV2.tsx)):
+super_admin escolhe escola/campus; para school_admin/campus_admin a seleção é derivada do seu
+`school_id`/`campus_id`.
+
+**Como o campus entra nas requests:** o hook
+[`useCampusFilter`](../src/hooks/useCampusFilter.ts) registra um **interceptor de request** que
+injeta `campus_id` automaticamente — em `params` para GET e no corpo para POST/PUT/PATCH — sempre que
+há campus selecionado, e faz `eject` do interceptor ao trocar de campus/desmontar. Assim as telas
+não precisam passar `campus_id` manualmente.
+
+## 7. Tema e design tokens
+
+Sistema de tema **dual** (CoreUI + tokens V2), em [`ThemeProvider`](../src/contexts/ThemeProvider.tsx)
++ [`ThemeContext`](../src/contexts/ThemeContext.ts) + [`src/theme.ts`](../src/theme.ts):
+
+- Estado `isDarkMode` inicializado de `localStorage` (`theme`) ou `prefers-color-scheme`.
+- Ao alternar, aplica no `<html>` `data-coreui-theme` (para o CoreUI) **e** `data-theme`, injeta as
+  cores como CSS vars `--app-*`, e toggla classes no `<body>` (`dark-theme`, e `dark-mode` via
+  `App.tsx`).
+- Tokens de design ficam em `src/styles-v2/`: `design-tokens.css`/`.ts` (auto-gerados do Figma),
+  `theme-variables.css`, `ThemeComponents.css`, `global.css`. A versão `.ts` (`design-tokens.ts`)
+  exporta `spacing`, `cornerRadius`, `colors`, etc., para uso em JS.
+
+## 8. Tipos gerados por Swagger
+
+```mermaid
+flowchart LR
+    SW["../walky-backend/swagger.json"] -->|"npm run generate:api"| GEN["src/API/WalkyAPI.ts + data-contracts.ts (gerados)"]
+    GEN --> SVC["services/*"]
+    HT["src/types/* (hand-written: extensões, unions, helpers)"] --> SVC
+    SVC --> Pages["pages-v2/*"]
+```
+
+- **Gerado:** `src/API/WalkyAPI.ts` (+ arquivos irmãos `Api.ts`, `data-contracts.ts`, `Admin.ts`,
+  `Users.ts`, `Auth.ts`, `Analytics.ts`, `Ambassadors.ts`, `Audit.ts`, `Age.ts`, `http-client.ts`) —
+  todos com o header "GENERATED VIA SWAGGER-TYPESCRIPT-API".
+- **Hand-written:** `src/types/*` (`ambassador`, `analytics`, `api`, `campus`, `place`, `placeType`,
+  `report`, `role`) — extensões/uniões específicas da UI que os services combinam com os tipos
+  gerados (ex.: `UserWithRoles extends Omit<User, ...>` em `userService.ts`).
+
+Regenerar após mudança de contrato no backend: `npm run generate:api`.
+
+## 9. Fluxo de dados ponta a ponta
+
+Exemplo: **abrir "Active Students" e exportar**.
+
+```mermaid
+sequenceDiagram
+    participant U as Admin
+    participant R as v2Routes (PermissionGuard)
+    participant P as ActiveStudents (pages-v2/Campus)
+    participant Q as React Query
+    participant S as userService
+    participant C as apiClient (WalkyAPI)
+    participant I as Axios interceptors
+    participant B as walky-backend
+
+    U->>R: navega /manage-students/active
+    R->>R: can('active_students','read')? sim
+    R->>P: monta a tela
+    P->>Q: useQuery(students)
+    Q->>S: userService.getUsers({page,limit,search})
+    S->>C: apiClient.api.adminUsersList(...)
+    C->>I: request → + Bearer token, + campus_id (useCampusFilter), + CSRF
+    I->>B: GET /api/admin/users?...&campus_id=...
+    B-->>I: 200 { users, pagination }
+    I-->>Q: normaliza → cacheia (staleTime 5min)
+    Q-->>P: dados
+    U->>P: clica "Export" (só visível se can('active_students','export'))
+    P->>P: gera CSV/PDF (ExportButton / html2pdf)
+```
+
+Erros: 401 → interceptor limpa token e vai a `/login`; 403 `ACCOUNT_DEACTIVATED` → modal;
+outros 4xx → React Query não retenta.
+
+## 10. Decisões e trade-offs
+
+| Decisão | Porquê | Trade-off |
+|---------|--------|-----------|
+| **Cliente HTTP gerado por Swagger** | Contrato único com o backend; menos drift; tipos grátis | Arquivo enorme `// @ts-nocheck`; precisa regenerar quando o backend muda |
+| **Service layer sobre o cliente gerado** | Isola telas de nomes/formatos do backend; centraliza normalização (`_id→id`, paginação) | Camada extra de indireção |
+| **Context + React Query (sem Redux/Zustand)** | Estado remoto no React Query; UI/seleção em Context simples; menos boilerplate | Sem store centralizada; seleção multi-tenant espalhada em contexts |
+| **Sessão em localStorage + sync por eventos** | Simples; funciona entre abas; sobrevive a reload | Suscetível a XSS (mitigado por CSP/backend); não é httpOnly |
+| **RBAC no cliente (matriz em `permissions.ts`)** | UX: esconder o que o usuário não pode; guardar rotas | Não é segurança — o backend precisa reforçar tudo |
+| **Rotas lazy + manualChunks** | Bundle inicial pequeno; Playground/Three.js isolados | Suspense/flash de loading por rota |
+| **`campus_id` via interceptor (`useCampusFilter`)** | Multi-tenant transparente; telas não passam campus manualmente | Interceptor global com efeito "mágico"; cuidado ao depurar |
+| **Sufixo `-v2` na camada de UI** | Redesign completo da UI preservando a arquitetura (ver folder-structure) | Coexistência de nomes; `assets/` legado ao lado de `assets-v2/` |
+
+---
+
+## Cross-links
+
+- [Visão geral](./overview.md) — propósito, público, stack.
+- [Estrutura de pastas](./folder-structure.md) — cada diretório e o sufixo `-v2`.

--- a/docs/business-rules.md
+++ b/docs/business-rules.md
@@ -1,47 +1,47 @@
-# Walky Admin — Regras de Negócio
+# Walky Admin — Business Rules
 
-> Regras extraídas **do código** do painel `walky-admin`. Cada regra cita o arquivo que a
-> implementa. Regras que dependem do backend (não confirmáveis só pelo admin) estão marcadas com
-> **(não confirmado no admin)**. O RBAC do admin é de **UX/apresentação**; a autorização efetiva é
-> do backend.
+> Rules extracted **from the code** of the `walky-admin` panel. Each rule cites the file that
+> implements it. Rules that depend on the backend (not verifiable from the admin alone) are marked
+> **(not confirmed in the admin)**. The admin's RBAC is **UX/presentation**; effective authorization
+> lives in the backend.
 >
-> Documento-irmão: [workflows.md](./workflows.md) (fluxos com diagramas).
-> Ver também [overview.md](./overview.md), [integrations.md](./integrations.md).
+> Companion document: [workflows.md](./workflows.md) (flows with diagrams).
+> See also [overview.md](./overview.md), [integrations.md](./integrations.md).
 
-## Índice
+## Table of Contents
 
-- [1. Matriz de permissões por role](#1-matriz-de-permissões-por-role)
-- [2. Hierarquia de atribuição de roles](#2-hierarquia-de-atribuição-de-roles)
-- [3. Regras de moderação e gestão de estudantes](#3-regras-de-moderação-e-gestão-de-estudantes)
-- [4. Nomes de roles e mapeamentos](#4-nomes-de-roles-e-mapeamentos)
-- [5. Regras de sessão e segurança](#5-regras-de-sessão-e-segurança)
-- [6. Regras de campus, geofences e ambassadors](#6-regras-de-campus-geofences-e-ambassadors)
-- [7. Validações de formulários](#7-validações-de-formulários)
-- [8. Proteção de rotas (route → resource)](#8-proteção-de-rotas-route--resource)
+- [1. Permission matrix by role](#1-permission-matrix-by-role)
+- [2. Role assignment hierarchy](#2-role-assignment-hierarchy)
+- [3. Moderation and student management rules](#3-moderation-and-student-management-rules)
+- [4. Role names and mappings](#4-role-names-and-mappings)
+- [5. Session and security rules](#5-session-and-security-rules)
+- [6. Campus, geofence, and ambassador rules](#6-campus-geofence-and-ambassador-rules)
+- [7. Form validations](#7-form-validations)
+- [8. Route protection (route → resource)](#8-route-protection-route--resource)
 - [Cross-links](#cross-links)
 
 ---
 
-## 1. Matriz de permissões por role
+## 1. Permission matrix by role
 
-**Arquivo:** `src/lib/permissions.ts` (`permissionMatrix`). Ações possíveis por recurso:
+**File:** `src/lib/permissions.ts` (`permissionMatrix`). Possible actions per resource:
 `read | create | update | delete | export | manage`.
 
-### Recursos (`PermissionResource`)
+### Resources (`PermissionResource`)
 
 Dashboard: `engagement`, `popular_features`, `user_interactions`, `community`, `student_safety`,
-`student_behavior`. Estudantes: `active_students`, `banned_students`, `inactive_students`,
-`disengaged_students`, `reported_content`. Conteúdo: `events_manager`, `events_insights`,
-`spaces_manager`, `spaces_insights`, `ideas_manager`, `ideas_insights`. Moderação: `report_safety`,
+`student_behavior`. Students: `active_students`, `banned_students`, `inactive_students`,
+`disengaged_students`, `reported_content`. Content: `events_manager`, `events_insights`,
+`spaces_manager`, `spaces_insights`, `ideas_manager`, `ideas_insights`. Moderation: `report_safety`,
 `report_history`. Admin: `campuses`, `ambassadors`, `role_management`.
 
-### Matriz consolidada (o que cada role pode)
+### Consolidated matrix (what each role can do)
 
-Legenda: **R**=read, **C**=create, **U**=update, **D**=delete, **E**=export, **M**=manage, **—**=sem acesso.
+Legend: **R**=read, **C**=create, **U**=update, **D**=delete, **E**=export, **M**=manage, **—**=no access.
 
-| Recurso | super_admin | school_admin | campus_admin | moderator | walky_internal |
+| Resource | super_admin | school_admin | campus_admin | moderator | walky_internal |
 |---|---|---|---|---|---|
-| **Dashboards** (todos os 6) | R, E | R, E | R, E | R | R |
+| **Dashboards** (all 6) | R, E | R, E | R, E | R | R |
 | `active_students` | R, U, E | R, U, E | R, U, E | — | — |
 | `banned_students` | R, U, E | R, U, E | R, U, E | — | — |
 | `inactive_students` | R, U, E | R, U, E | R, U, E | — | — |
@@ -59,100 +59,101 @@ Legenda: **R**=read, **C**=create, **U**=update, **D**=delete, **E**=export, **M
 | `ambassadors` | R, C, D | R, C, D | R, C, D | — | R |
 | `role_management` | R, C, U, D, M | R, C, U, D, M | R, C, U, D, M | — | R |
 
-**Observações do código:**
-- `super_admin`, `school_admin` e `campus_admin` têm **matriz idêntica** em `permissions.ts`. A
-  diferença entre eles é **escopo/tenant** (super vê todas as escolas; school vê sua escola; campus
-  seu campus), imposto no backend e refletido nos seletores de escola/campus (ver §5 e
-  [workflows.md §6](./workflows.md#6-troca-de-escola--campus-multi-tenant)).
-- **`moderator`:** dashboards **sem export**; **sem acesso** à gestão de estudantes e à área Admin;
-  seu poder está em **Moderação** (report_safety/report_history: R, U, E).
-- **`walky_internal`** (funcionário interno, "read-only"): tudo **R** apenas (inclui `campuses`,
-  `ambassadors`, `role_management` em read); **sem** moderação e **sem** gestão de estudantes.
-- Role **desconhecido** → `noPermissions` (tudo `false`), via `getPermissions()`.
+**Notes from the code:**
+- `super_admin`, `school_admin`, and `campus_admin` have an **identical matrix** in `permissions.ts`.
+  The difference between them is **scope/tenant** (super sees all schools; school sees its school;
+  campus sees its campus), enforced in the backend and reflected in the school/campus selectors (see
+  §5 and [workflows.md §6](./workflows.md#6-switching-school--campus-multi-tenant)).
+- **`moderator`:** dashboards **without export**; **no access** to student management or the Admin
+  area; its power is in **Moderation** (report_safety/report_history: R, U, E).
+- **`walky_internal`** (internal employee, "read-only"): everything **R** only (including `campuses`,
+  `ambassadors`, `role_management` in read); **no** moderation and **no** student management.
+- **Unknown** role → `noPermissions` (everything `false`), via `getPermissions()`.
 
-> **(não confirmado no admin)** O backend é a fonte real da autorização; a matriz acima só governa a
-> UI/rotas do admin.
+> **(not confirmed in the admin)** The backend is the real source of authorization; the matrix above
+> only governs the admin's UI/routes.
 
 ---
 
-## 2. Hierarquia de atribuição de roles
+## 2. Role assignment hierarchy
 
-**Arquivo:** `src/lib/permissions.ts` (`roleHierarchy`, `getAssignableRoles`, `canAssignRole`).
+**File:** `src/lib/permissions.ts` (`roleHierarchy`, `getAssignableRoles`, `canAssignRole`).
 
-Quem pode **atribuir** qual role a outros membros (usado no RoleManagement / CreateMemberModal):
+Who can **assign** which role to other members (used in RoleManagement / CreateMemberModal):
 
-| Role do usuário | Pode atribuir |
+| User's role | Can assign |
 |---|---|
 | `super_admin` | `school_admin`, `campus_admin`, `moderator` |
 | `school_admin` | `campus_admin`, `moderator` |
 | `campus_admin` | `moderator` |
-| `moderator` | (nenhum) |
-| `walky_internal` | (nenhum) |
+| `moderator` | (none) |
+| `walky_internal` | (none) |
 
-- Ninguém (via essa hierarquia) pode atribuir `super_admin` ou `walky_internal` — não aparecem em
-  nenhuma lista de `roleHierarchy`.
-- `getAssignableRoleDisplayNames(userRole)` traduz para os nomes de exibição usados nos dropdowns.
+- No one (via this hierarchy) can assign `super_admin` or `walky_internal` — they do not appear in
+  any `roleHierarchy` list.
+- `getAssignableRoleDisplayNames(userRole)` translates to the display names used in the dropdowns.
 - Helpers: `canAssignRole(userRole, targetRole)`, `canAssignRoleByDisplayName(userRole, displayName)`.
 
 ---
 
-## 3. Regras de moderação e gestão de estudantes
+## 3. Moderation and student management rules
 
-**Arquivos:** `src/pages-v2/Campus/components/{StudentTable,BannedStudentTable,DeactivatedStudentTable}.tsx`,
-`src/pages-v2/Moderation/ReportSafety/ReportSafety.tsx`, modais em `src/components-v2/*`,
-`src/services/reportService.ts` (legado — ver nota).
+**Files:** `src/pages-v2/Campus/components/{StudentTable,BannedStudentTable,DeactivatedStudentTable}.tsx`,
+`src/pages-v2/Moderation/ReportSafety/ReportSafety.tsx`, modals in `src/components-v2/*`,
+`src/services/reportService.ts` (legacy — see note).
 
-### 3.1 Ações sobre estudantes (endpoints v2 reais)
+### 3.1 Student actions (actual v2 endpoints)
 
-| Ação | Endpoint | Payload / Regra |
+| Action | Endpoint | Payload / Rule |
 |---|---|---|
-| Ban | `PUT /api/admin/v2/students/{id}/lock-settings` | `{ isLocked:true, lockReason, lockDuration }` — `lockReason` obrigatório (modal bloqueia se vazio) |
+| Ban | `PUT /api/admin/v2/students/{id}/lock-settings` | `{ isLocked:true, lockReason, lockDuration }` — `lockReason` required (modal blocks if empty) |
 | Unban | `POST /api/admin/v2/students/{id}/unban` | — |
-| Deactivate | `DELETE /api/admin/v2/students/{id}` | Estudante é **notificado por email** sobre a desativação (texto do `DeactivateUserModal`). Reversível. |
-| Activate | `POST /api/admin/v2/students/{id}/activate` | Reativa conta desativada |
-| Flag | `POST /api/admin/v2/students/{id}/flag` | `{ reason }` (motivo pode ser auto-gerado a partir do email do admin) |
+| Deactivate | `DELETE /api/admin/v2/students/{id}` | The student is **notified by email** about the deactivation (text from `DeactivateUserModal`). Reversible. |
+| Activate | `POST /api/admin/v2/students/{id}/activate` | Reactivates a deactivated account |
+| Flag | `POST /api/admin/v2/students/{id}/flag` | `{ reason }` (the reason may be auto-generated from the admin's email) |
 | Unflag | `POST /api/admin/v2/students/{id}/unflag` | — |
 
-**Durações de ban** (`BanUserModal`, mapeadas para dias): 1, 3, 7, 14, 30, 90.
-**"Permanent" → 36500 dias** (100 anos). O modal também tem o checkbox **"Resolve all related reports
-for this user"** (default marcado).
+**Ban durations** (`BanUserModal`, mapped to days): 1, 3, 7, 14, 30, 90.
+**"Permanent" → 36500 days** (100 years). The modal also has the **"Resolve all related reports
+for this user"** checkbox (checked by default).
 
-### 3.2 Status de "onboarding incompleto" (ActiveStudents)
+### 3.2 "Incomplete onboarding" status (ActiveStudents)
 
-**Arquivo:** `src/pages-v2/Campus/ActiveStudents/ActiveStudents.tsx`. Um estudante é exibido como
-**`incomplete`** quando `isOnboarded === false` **ou** possui **menos de 3 interesses**
-(`interestCount < 3`). Caso contrário mantém o `status` do backend.
+**File:** `src/pages-v2/Campus/ActiveStudents/ActiveStudents.tsx`. A student is displayed as
+**`incomplete`** when `isOnboarded === false` **or** they have **fewer than 3 interests**
+(`interestCount < 3`). Otherwise the backend's `status` is kept.
 
 ### 3.3 Reports (ReportSafety)
 
-- **Status (labels da tela):** `Pending review`, `Under evaluation`, `Resolved`, `Dismissed`.
-- **Nota obrigatória:** mudar status para **Resolved** ou **Dismissed** exige nota (via
-  `WriteNoteModal`, não-vazia, máx **500** caracteres). A nota (`adminV2ReportsNoteCreate`) é gravada
-  **antes** da mudança de status (`adminV2ReportsStatusPartialUpdate`). Outros status mudam direto.
-- **Flag/Unflag do item denunciado:** roteia por tipo — `Students`/`Events`/`Ideas`/`Spaces`
-  (`adminV2{Tipo}FlagCreate/UnflagCreate`), com update otimista da lista `["reports"]`.
-- **Banir/Desativar a partir do report:** reutiliza `adminV2StudentsLockSettingsUpdate` e
+- **Statuses (screen labels):** `Pending review`, `Under evaluation`, `Resolved`, `Dismissed`.
+- **Mandatory note:** changing a status to **Resolved** or **Dismissed** requires a note (via
+  `WriteNoteModal`, non-empty, max **500** characters). The note (`adminV2ReportsNoteCreate`) is
+  written **before** the status change (`adminV2ReportsStatusPartialUpdate`). Other statuses change
+  directly.
+- **Flag/Unflag the reported item:** routed by type — `Students`/`Events`/`Ideas`/`Spaces`
+  (`adminV2{Type}FlagCreate/UnflagCreate`), with an optimistic update of the `["reports"]` list.
+- **Ban/Deactivate from the report:** reuses `adminV2StudentsLockSettingsUpdate` and
   `adminV2StudentsDelete`.
 
-### 3.4 Camada `reportService` (legado / não usado pela tela)
+### 3.4 `reportService` layer (legacy / not used by the screen)
 
-`src/services/reportService.ts` implementa outra convenção de moderação, apontando para endpoints
-**sem `v2`**: `adminReportsList/Detail/StatusPartialUpdate/BanUserCreate/BulkPartialUpdate`, com
+`src/services/reportService.ts` implements another moderation convention, pointing to endpoints
+**without `v2`**: `adminReportsList/Detail/StatusPartialUpdate/BanUserCreate/BulkPartialUpdate`, with
 - **Status:** `pending | under_review | resolved | dismissed`
 - **Bulk `action`:** `resolve | dismiss | under_review`
-- **Ban a partir do report:** `{ ban_duration, ban_reason, resolve_related_reports }`
-- **removeUser:** `DELETE /api/admin/users/{id}/remove` com `{ reason, sendEmail }` (default `sendEmail=true`)
+- **Ban from the report:** `{ ban_duration, ban_reason, resolve_related_reports }`
+- **removeUser:** `DELETE /api/admin/users/{id}/remove` with `{ reason, sendEmail }` (default `sendEmail=true`)
 
-> A tela `ReportSafety` **não** usa esse service (usa `adminV2Reports*`). Tratado como **camada
-> antiga**; mantido no repo mas fora do caminho ativo de UI.
+> The `ReportSafety` screen does **not** use this service (it uses `adminV2Reports*`). Treated as an
+> **old layer**; kept in the repo but outside the active UI path.
 
 ---
 
-## 4. Nomes de roles e mapeamentos
+## 4. Role names and mappings
 
-**Arquivo:** `src/lib/permissions.ts` (`roleDisplayNameMap`, `displayNameToRoleMap`).
+**File:** `src/lib/permissions.ts` (`roleDisplayNameMap`, `displayNameToRoleMap`).
 
-| Nome interno | Nome de exibição |
+| Internal name | Display name |
 |---|---|
 | `super_admin` | Walky Admin |
 | `school_admin` | School Admin |
@@ -160,128 +161,129 @@ for this user"** (default marcado).
 | `moderator` | Moderator |
 | `walky_internal` | Walky Internal |
 
-**Allowlist de login** (`src/pages-v2/LoginV2/LoginV2.tsx`) — roles aceitos no painel:
+**Login allowlist** (`src/pages-v2/LoginV2/LoginV2.tsx`) — roles accepted into the panel:
 `super_admin`, `walky_internal`, `school_admin`, `campus_admin`, `editor`, `moderator`, `staff`,
-`viewer`. (Note que `editor`, `staff`, `viewer` **passam no login mas não têm entrada na
-`permissionMatrix`** → cairiam em `noPermissions` para todo recurso mapeado.)
+`viewer`. (Note that `editor`, `staff`, `viewer` **pass login but have no entry in the
+`permissionMatrix`** → they would fall into `noPermissions` for every mapped resource.)
 
-**Roles atribuíveis via `rolesService.assignRole`** (`src/services/rolesService.ts`) — o tipo aceita
-um conjunto maior: `super_admin | school_admin | campus_admin | editor | moderator | staff | viewer |
-student | faculty | parent`. **(não confirmado no admin)** quais são de fato válidos é decidido pelo
-backend.
+**Roles assignable via `rolesService.assignRole`** (`src/services/rolesService.ts`) — the type accepts
+a larger set: `super_admin | school_admin | campus_admin | editor | moderator | staff | viewer |
+student | faculty | parent`. **(not confirmed in the admin)** which ones are actually valid is decided
+by the backend.
 
 ---
 
-## 5. Regras de sessão e segurança
+## 5. Session and security rules
 
-**Arquivos:** `src/hooks/useAuth.ts`, `src/API/index.ts`, `src/layout-v2/TopbarV2/TopbarV2.tsx`,
+**Files:** `src/hooks/useAuth.ts`, `src/API/index.ts`, `src/layout-v2/TopbarV2/TopbarV2.tsx`,
 `src/contexts/DeactivatedUserContext.tsx`, `src/pages-v2/ForcePasswordChange/ForcePasswordChange.tsx`.
 
-1. **Fonte de verdade da sessão = `localStorage`** (`token`, `user`). Não há cookie de sessão do lado
-   do app para auth (mas `withCredentials: true` é usado para o cookie de CSRF).
-2. **Token JWT em `Authorization: Bearer`** injetado em toda request pelo interceptor. Se `user` no
-   storage estiver corrompido, `useAuth` limpa `token` + `user`.
-3. **CSRF:** em requests **não-GET** (`!get/head/options`), o interceptor lê o cookie CSRF
-   (`csrf_cookie_rr` → `XSRF-TOKEN` → `csrf_token` → `_csrf`) e o envia em `X-CSRF-Token` **e**
+1. **Session source of truth = `localStorage`** (`token`, `user`). There is no app-side session
+   cookie for auth (but `withCredentials: true` is used for the CSRF cookie).
+2. **JWT token in `Authorization: Bearer`** injected into every request by the interceptor. If `user`
+   in storage is corrupted, `useAuth` clears `token` + `user`.
+3. **CSRF:** on **non-GET** requests (`!get/head/options`), the interceptor reads the CSRF cookie
+   (`csrf_cookie_rr` → `XSRF-TOKEN` → `csrf_token` → `_csrf`) and sends it in `X-CSRF-Token` **and**
    `X-XSRF-Token`.
-4. **401 → logout:** o interceptor remove `token` e redireciona a `/login` (se ainda não estiver lá).
-   **Não há refresh token** no admin: o `refresh_token` do login não é persistido e
-   `POST /api/refresh-token` não é chamado.
-5. **403 `ACCOUNT_DEACTIVATED` / `USER_DEACTIVATED` → modal de conta desativada** (bloqueante). Um
-   403 comum de permissão **não** abre o modal.
-6. **Troca forçada de senha:** se `require_password_change` no login, o usuário é levado a
-   `/force-password-change` (nova senha mín. 8, confirmar igual; `currentPassword` vazio por ser reset
-   forçado). A rota é pública mas a página revalida sessão e a flag.
-7. **Sync entre abas:** logout/login numa aba propaga para outras via evento nativo `storage`
-   (`useAuth`), e na mesma aba via evento custom `auth:user-updated`.
-8. **Logout:** remove `token`+`user` (Topbar) — **não** remove `selectedSchool`/`selectedCampus`. O
-   logout de conta desativada remove também `refreshToken`. Ambos usam `window.location.href = "/login"`.
-9. **RBAC é client-side (UX):** `AuthGuard` protege a área autenticada e `PermissionGuard` cada rota;
-   ações inline somem via `can*()`/`fallback="hidden"`. **A autorização real é do backend.**
-10. **Logout de todos os dispositivos** e **2FA** existem em AdministratorSettings
-    (`adminV2SettingsLogoutAllCreate`, `adminProfile2Fa{Enable,Disable}Create`) — a validação/efeito
-    real é do backend. **(não confirmado no admin)**.
+4. **401 → logout:** the interceptor removes `token` and redirects to `/login` (if not already there).
+   **There is no refresh token** in the admin: the login's `refresh_token` is not persisted and
+   `POST /api/refresh-token` is not called.
+5. **403 `ACCOUNT_DEACTIVATED` / `USER_DEACTIVATED` → deactivated-account modal** (blocking). An
+   ordinary permission 403 does **not** open the modal.
+6. **Forced password change:** if `require_password_change` at login, the user is taken to
+   `/force-password-change` (new password min. 8, confirm matching; `currentPassword` empty because it
+   is a forced reset). The route is public but the page revalidates the session and the flag.
+7. **Cross-tab sync:** logout/login in one tab propagates to others via the native `storage` event
+   (`useAuth`), and within the same tab via the custom `auth:user-updated` event.
+8. **Logout:** removes `token`+`user` (Topbar) — does **not** remove `selectedSchool`/`selectedCampus`.
+   The deactivated-account logout also removes `refreshToken`. Both use `window.location.href = "/login"`.
+9. **RBAC is client-side (UX):** `AuthGuard` protects the authenticated area and `PermissionGuard`
+   protects each route; inline actions disappear via `can*()`/`fallback="hidden"`. **Real authorization
+   lives in the backend.**
+10. **Log out of all devices** and **2FA** exist in AdministratorSettings
+    (`adminV2SettingsLogoutAllCreate`, `adminProfile2Fa{Enable,Disable}Create`) — the real
+    validation/effect lives in the backend. **(not confirmed in the admin)**.
 
-> **Nota (segurança):** a base do cliente gerado remove o sufixo `/api` (`baseURL.replace(/\/api\/?$/, "")`)
-> porque rotas admin já incluem `/api/...` e rotas legadas batem na raiz (`/campus`, `/ambassadors`).
-> Ver [workflows.md §T1](./workflows.md#t1-camada-axios-interceptors-csrf-token).
+> **Note (security):** the generated client's base strips the `/api` suffix (`baseURL.replace(/\/api\/?$/, "")`)
+> because admin routes already include `/api/...` and legacy routes hit the root (`/campus`, `/ambassadors`).
+> See [workflows.md §T1](./workflows.md#t1-axios-layer-interceptors-csrf-token).
 
 ---
 
-## 6. Regras de campus, geofences e ambassadors
+## 6. Campus, geofence, and ambassador rules
 
-**Arquivos:** `src/services/campusService.ts`, `src/services/campusSyncService.ts`,
+**Files:** `src/services/campusService.ts`, `src/services/campusSyncService.ts`,
 `src/pages-v2/CampusBoundary/CampusBoundary.tsx`, `src/services/ambassadorService.ts`,
 `src/components-v2/AddAmbassadorModal/AddAmbassadorModal.tsx`.
 
 ### 6.1 Campus
 
-- **Campos do create/update** (`campusService.create/update`): **obrigatórios** `campus_name`,
-  `phone_number`, `address`, `city`, `state`, `zip`, `time_zone`. **Opcionais** `campus_short_name`,
+- **Create/update fields** (`campusService.create/update`): **required** `campus_name`,
+  `phone_number`, `address`, `city`, `state`, `zip`, `time_zone`. **Optional** `campus_short_name`,
   `image_url`, `ambassador_ids[]`, `coordinates` (Polygon), `dawn_to_dusk[]`, `is_active` (default `true`).
-- **`campusService.getAll`** trata **404 como lista vazia** (sem erro). O create loga detalhes extras
-  em erro 400 (validação do backend).
-- **Mapeamento** `_id → id` para compat com o frontend.
+- **`campusService.getAll`** treats **404 as an empty list** (no error). Create logs extra details on
+  a 400 error (backend validation).
+- **Mapping** `_id → id` for frontend compatibility.
 
 ### 6.2 Geofence (boundary)
 
-- Polígono desenhado no Google Maps precisa de **mínimo 3 vértices**; o anel é **fechado** (primeiro
-  ponto repetido no fim) e salvo como GeoJSON `Polygon` com coords **`[lng, lat]`** (WGS84).
-- **`previewCampusBoundary(id)`** retorna `bounds`, `center`, `area_sqm`/`area_acres`, `search_points`
-  usados no sync de places.
-- **Chave do Google Maps hardcoded** em `CampusBoundary.tsx` (a env `VITE_GOOGLE_MAPS_API_KEY`
-  sugerida no `.env.example` **não é lida**). Ver [integrations.md](./integrations.md).
+- A polygon drawn on Google Maps needs a **minimum of 3 vertices**; the ring is **closed** (first
+  point repeated at the end) and saved as a GeoJSON `Polygon` with coords **`[lng, lat]`** (WGS84).
+- **`previewCampusBoundary(id)`** returns `bounds`, `center`, `area_sqm`/`area_acres`, `search_points`
+  used in the place sync.
+- **Google Maps key hardcoded** in `CampusBoundary.tsx` (the `VITE_GOOGLE_MAPS_API_KEY` env suggested
+  in `.env.example` is **not read**). See [integrations.md](./integrations.md).
 
-### 6.3 Sync de places
+### 6.3 Place sync
 
 `campusSyncService`: `syncCampus`, `syncAllCampuses`, `getSyncLogs`, `getCampusesWithSyncStatus`,
-`previewCampusBoundary`. Status de sync: `completed | failed | partial | in_progress`. Cada sync
-reporta `places_added/updated/removed`, `api_calls_used`, `sync_duration_ms`, `errors[]`.
-**(não confirmado no admin)** as regras de quantas chamadas ao Google Places / limites são do backend.
+`previewCampusBoundary`. Sync status: `completed | failed | partial | in_progress`. Each sync
+reports `places_added/updated/removed`, `api_calls_used`, `sync_duration_ms`, `errors[]`.
+**(not confirmed in the admin)** the rules for how many Google Places calls / limits live in the backend.
 
 ### 6.4 Ambassadors
 
-- Campos do create (`ambassadorService.create`): `name`, `email` (obrigatórios); opcionais `phone`,
+- Create fields (`ambassadorService.create`): `name`, `email` (required); optional `phone`,
   `student_id`, `is_active` (default `true`), `profile_image_url`, `bio`, `graduation_year`, `major`.
-- **`getAll` é fail-soft** (retorna `[]` em erro); as demais operações propagam erro.
-- No `AddAmbassadorModal`, estudantes são buscados por **nome exato**
-  (`adminV2MembersList({ role:"student", exactMatch:true })`) e cada seleção vira um ambassador com
-  `{ name, email, user_id, school_id, campuses_id[] }`.
-- Ações gated por `canCreate("ambassadors")` / `canDelete("ambassadors")`.
+- **`getAll` is fail-soft** (returns `[]` on error); the other operations propagate errors.
+- In `AddAmbassadorModal`, students are searched by **exact name**
+  (`adminV2MembersList({ role:"student", exactMatch:true })`) and each selection becomes an ambassador
+  with `{ name, email, user_id, school_id, campuses_id[] }`.
+- Actions gated by `canCreate("ambassadors")` / `canDelete("ambassadors")`.
 
 ---
 
-## 7. Validações de formulários
+## 7. Form validations
 
-Fonte: componentes de cada tela/modal citados.
+Source: the components of each screen/modal cited.
 
-| Formulário | Campo | Regra | Arquivo |
+| Form | Field | Rule | File |
 |---|---|---|---|
-| Login | email/senha | ambos `required`; role deve estar na allowlist | `LoginV2.tsx` |
-| Force password change | newPassword | `>= 8` chars e `=== confirmPassword` | `ForcePasswordChange.tsx` |
-| Recover — OTP | otp | exatamente **6 dígitos** (`/^\d{6}$/`), trim; máx 6 tentativas (lockout) | `RecoverPasswordV2/VerifyCodeStep.tsx` |
-| Recover — reset | password | `>= 8` e `=== confirm`; erros de backend "Password validation failed" listados | `RecoverPasswordV2/ResetPasswordStep.tsx` |
-| Settings — senha | newPassword | `>= 8`, confirmar igual, `currentPassword` obrigatório | `AdministratorSettings.tsx` |
-| Settings — avatar | avatar | imagem, máx **5MB** | `AdministratorSettings.tsx` |
-| Ban user | reason | **obrigatório** (botão desabilitado se vazio); duração default "1 Day" | `BanUserModal.tsx` |
-| Write note (report) | note | não-vazia; `maxCharacters` **500** | `WriteNoteModal.tsx` |
-| Create member | firstName, lastName, email, role | todos obrigatórios; email formato; role filtrado por hierarquia | `CreateMemberModal.tsx` |
-| Campus | campus_name, phone_number, address, city, state, zip, time_zone | obrigatórios | `campusService.ts` / form da página |
-| Ambassador | name, email | obrigatórios | `ambassadorService.ts` / `AddAmbassadorModal.tsx` |
+| Login | email/password | both `required`; role must be in the allowlist | `LoginV2.tsx` |
+| Force password change | newPassword | `>= 8` chars and `=== confirmPassword` | `ForcePasswordChange.tsx` |
+| Recover — OTP | otp | exactly **6 digits** (`/^\d{6}$/`), trimmed; max 6 attempts (lockout) | `RecoverPasswordV2/VerifyCodeStep.tsx` |
+| Recover — reset | password | `>= 8` and `=== confirm`; backend "Password validation failed" errors listed | `RecoverPasswordV2/ResetPasswordStep.tsx` |
+| Settings — password | newPassword | `>= 8`, confirm matching, `currentPassword` required | `AdministratorSettings.tsx` |
+| Settings — avatar | avatar | image, max **5MB** | `AdministratorSettings.tsx` |
+| Ban user | reason | **required** (button disabled if empty); default duration "1 Day" | `BanUserModal.tsx` |
+| Write note (report) | note | non-empty; `maxCharacters` **500** | `WriteNoteModal.tsx` |
+| Create member | firstName, lastName, email, role | all required; email format; role filtered by hierarchy | `CreateMemberModal.tsx` |
+| Campus | campus_name, phone_number, address, city, state, zip, time_zone | required | `campusService.ts` / page form |
+| Ambassador | name, email | required | `ambassadorService.ts` / `AddAmbassadorModal.tsx` |
 
-> Muitas validações são **duplicadas no backend** — o admin faz a validação de UX; o backend rejeita
-> definitivamente. **(não confirmado no admin)** os limites exatos do backend (ex.: política de senha).
+> Many validations are **duplicated in the backend** — the admin does the UX validation; the backend
+> rejects definitively. **(not confirmed in the admin)** the exact backend limits (e.g., password policy).
 
 ---
 
-## 8. Proteção de rotas (route → resource)
+## 8. Route protection (route → resource)
 
-**Arquivo:** `src/lib/permissions.ts` (`routeResourceMap`, `canAccessRoute`) + `src/routes/v2Routes.tsx`.
+**File:** `src/lib/permissions.ts` (`routeResourceMap`, `canAccessRoute`) + `src/routes/v2Routes.tsx`.
 
-Cada rota mapeada a um recurso é protegida por `PermissionGuard` com `action = 'read'`
+Each route mapped to a resource is protected by `PermissionGuard` with `action = 'read'`
 (`fallback="redirect"` → `/dashboard/engagement`).
 
-| Rota | Recurso |
+| Route | Resource |
 |---|---|
 | `/dashboard/engagement` | `engagement` |
 | `/dashboard/popular-features` | `popular_features` |
@@ -299,24 +301,24 @@ Cada rota mapeada a um recurso é protegida por `PermissionGuard` com `action = 
 | `/report-safety` · `/report-history` | `report_safety` · `report_history` |
 | `/admin/campuses` · `/admin/ambassadors` · `/admin/role-management` | `campuses` · `ambassadors` · `role_management` |
 
-**Regras de `canAccessRoute`:**
-- Rota **sem** mapeamento → **permitida por padrão** (ex.: `/admin/settings` — sem `PermissionGuard`
-  no roteador; qualquer admin autenticado acessa).
-- Rota mapeada → exige `hasPermission(role, resource, 'read')`.
-- `/manage-students/deactivated` mapeia para o recurso **`inactive_students`** (nome interno difere
-  do caminho "deactivated").
-- Rotas do **Playground** (14 visualizações) e o `*` (404) não têm guard de permissão.
-- Redirects legados: `/campuses`, `/ambassadors`, `/role-management` → `/admin/...`.
+**`canAccessRoute` rules:**
+- Route **without** a mapping → **allowed by default** (e.g., `/admin/settings` — no `PermissionGuard`
+  in the router; any authenticated admin can access it).
+- Mapped route → requires `hasPermission(role, resource, 'read')`.
+- `/manage-students/deactivated` maps to the **`inactive_students`** resource (the internal name
+  differs from the "deactivated" path).
+- **Playground** routes (14 views) and the `*` (404) have no permission guard.
+- Legacy redirects: `/campuses`, `/ambassadors`, `/role-management` → `/admin/...`.
 
 ---
 
 ## Cross-links
 
-- [workflows.md](./workflows.md) — fluxos de ponta a ponta com diagramas Mermaid.
-- [overview.md](./overview.md) — propósito, stack, público-alvo, env vars.
-- [integrations.md](./integrations.md) — camada de API e integrações (Google Maps, etc.).
-- [conventions.md](./conventions.md) — convenções de código.
-- Controllers do backend:
+- [workflows.md](./workflows.md) — end-to-end flows with Mermaid diagrams.
+- [overview.md](./overview.md) — purpose, stack, audience, env vars.
+- [integrations.md](./integrations.md) — API layer and integrations (Google Maps, etc.).
+- [conventions.md](./conventions.md) — code conventions.
+- Backend controllers:
   [admin/admin-students-controller.md](./admin/admin-students-controller.md),
   [admin/admin-reports-controller.md](./admin/admin-reports-controller.md),
   [admin/admin-settings-controller.md](./admin/admin-settings-controller.md),

--- a/docs/business-rules.md
+++ b/docs/business-rules.md
@@ -1,0 +1,323 @@
+# Walky Admin — Regras de Negócio
+
+> Regras extraídas **do código** do painel `walky-admin`. Cada regra cita o arquivo que a
+> implementa. Regras que dependem do backend (não confirmáveis só pelo admin) estão marcadas com
+> **(não confirmado no admin)**. O RBAC do admin é de **UX/apresentação**; a autorização efetiva é
+> do backend.
+>
+> Documento-irmão: [workflows.md](./workflows.md) (fluxos com diagramas).
+> Ver também [overview.md](./overview.md), [integrations.md](./integrations.md).
+
+## Índice
+
+- [1. Matriz de permissões por role](#1-matriz-de-permissões-por-role)
+- [2. Hierarquia de atribuição de roles](#2-hierarquia-de-atribuição-de-roles)
+- [3. Regras de moderação e gestão de estudantes](#3-regras-de-moderação-e-gestão-de-estudantes)
+- [4. Nomes de roles e mapeamentos](#4-nomes-de-roles-e-mapeamentos)
+- [5. Regras de sessão e segurança](#5-regras-de-sessão-e-segurança)
+- [6. Regras de campus, geofences e ambassadors](#6-regras-de-campus-geofences-e-ambassadors)
+- [7. Validações de formulários](#7-validações-de-formulários)
+- [8. Proteção de rotas (route → resource)](#8-proteção-de-rotas-route--resource)
+- [Cross-links](#cross-links)
+
+---
+
+## 1. Matriz de permissões por role
+
+**Arquivo:** `src/lib/permissions.ts` (`permissionMatrix`). Ações possíveis por recurso:
+`read | create | update | delete | export | manage`.
+
+### Recursos (`PermissionResource`)
+
+Dashboard: `engagement`, `popular_features`, `user_interactions`, `community`, `student_safety`,
+`student_behavior`. Estudantes: `active_students`, `banned_students`, `inactive_students`,
+`disengaged_students`, `reported_content`. Conteúdo: `events_manager`, `events_insights`,
+`spaces_manager`, `spaces_insights`, `ideas_manager`, `ideas_insights`. Moderação: `report_safety`,
+`report_history`. Admin: `campuses`, `ambassadors`, `role_management`.
+
+### Matriz consolidada (o que cada role pode)
+
+Legenda: **R**=read, **C**=create, **U**=update, **D**=delete, **E**=export, **M**=manage, **—**=sem acesso.
+
+| Recurso | super_admin | school_admin | campus_admin | moderator | walky_internal |
+|---|---|---|---|---|---|
+| **Dashboards** (todos os 6) | R, E | R, E | R, E | R | R |
+| `active_students` | R, U, E | R, U, E | R, U, E | — | — |
+| `banned_students` | R, U, E | R, U, E | R, U, E | — | — |
+| `inactive_students` | R, U, E | R, U, E | R, U, E | — | — |
+| `disengaged_students` | R, E | R, E | R, E | — | — |
+| `reported_content` | R, U, E | R, U, E | R, U, E | — | — |
+| `events_manager` | R, U, D, E | R, U, D, E | R, U, D, E | R | R |
+| `events_insights` | R, E | R, E | R, E | R | R |
+| `spaces_manager` | R, U, D, E | R, U, D, E | R, U, D, E | R | R |
+| `spaces_insights` | R, E | R, E | R, E | R | R |
+| `ideas_manager` | R, U, D, E | R, U, D, E | R, U, D, E | R | R |
+| `ideas_insights` | R, E | R, E | R, E | R | R |
+| `report_safety` | R, U, E | R, U, E | R, U, E | R, U, E | — |
+| `report_history` | R, U, E | R, U, E | R, U, E | R, U, E | — |
+| `campuses` | R, U | R, U | R, U | — | R |
+| `ambassadors` | R, C, D | R, C, D | R, C, D | — | R |
+| `role_management` | R, C, U, D, M | R, C, U, D, M | R, C, U, D, M | — | R |
+
+**Observações do código:**
+- `super_admin`, `school_admin` e `campus_admin` têm **matriz idêntica** em `permissions.ts`. A
+  diferença entre eles é **escopo/tenant** (super vê todas as escolas; school vê sua escola; campus
+  seu campus), imposto no backend e refletido nos seletores de escola/campus (ver §5 e
+  [workflows.md §6](./workflows.md#6-troca-de-escola--campus-multi-tenant)).
+- **`moderator`:** dashboards **sem export**; **sem acesso** à gestão de estudantes e à área Admin;
+  seu poder está em **Moderação** (report_safety/report_history: R, U, E).
+- **`walky_internal`** (funcionário interno, "read-only"): tudo **R** apenas (inclui `campuses`,
+  `ambassadors`, `role_management` em read); **sem** moderação e **sem** gestão de estudantes.
+- Role **desconhecido** → `noPermissions` (tudo `false`), via `getPermissions()`.
+
+> **(não confirmado no admin)** O backend é a fonte real da autorização; a matriz acima só governa a
+> UI/rotas do admin.
+
+---
+
+## 2. Hierarquia de atribuição de roles
+
+**Arquivo:** `src/lib/permissions.ts` (`roleHierarchy`, `getAssignableRoles`, `canAssignRole`).
+
+Quem pode **atribuir** qual role a outros membros (usado no RoleManagement / CreateMemberModal):
+
+| Role do usuário | Pode atribuir |
+|---|---|
+| `super_admin` | `school_admin`, `campus_admin`, `moderator` |
+| `school_admin` | `campus_admin`, `moderator` |
+| `campus_admin` | `moderator` |
+| `moderator` | (nenhum) |
+| `walky_internal` | (nenhum) |
+
+- Ninguém (via essa hierarquia) pode atribuir `super_admin` ou `walky_internal` — não aparecem em
+  nenhuma lista de `roleHierarchy`.
+- `getAssignableRoleDisplayNames(userRole)` traduz para os nomes de exibição usados nos dropdowns.
+- Helpers: `canAssignRole(userRole, targetRole)`, `canAssignRoleByDisplayName(userRole, displayName)`.
+
+---
+
+## 3. Regras de moderação e gestão de estudantes
+
+**Arquivos:** `src/pages-v2/Campus/components/{StudentTable,BannedStudentTable,DeactivatedStudentTable}.tsx`,
+`src/pages-v2/Moderation/ReportSafety/ReportSafety.tsx`, modais em `src/components-v2/*`,
+`src/services/reportService.ts` (legado — ver nota).
+
+### 3.1 Ações sobre estudantes (endpoints v2 reais)
+
+| Ação | Endpoint | Payload / Regra |
+|---|---|---|
+| Ban | `PUT /api/admin/v2/students/{id}/lock-settings` | `{ isLocked:true, lockReason, lockDuration }` — `lockReason` obrigatório (modal bloqueia se vazio) |
+| Unban | `POST /api/admin/v2/students/{id}/unban` | — |
+| Deactivate | `DELETE /api/admin/v2/students/{id}` | Estudante é **notificado por email** sobre a desativação (texto do `DeactivateUserModal`). Reversível. |
+| Activate | `POST /api/admin/v2/students/{id}/activate` | Reativa conta desativada |
+| Flag | `POST /api/admin/v2/students/{id}/flag` | `{ reason }` (motivo pode ser auto-gerado a partir do email do admin) |
+| Unflag | `POST /api/admin/v2/students/{id}/unflag` | — |
+
+**Durações de ban** (`BanUserModal`, mapeadas para dias): 1, 3, 7, 14, 30, 90.
+**"Permanent" → 36500 dias** (100 anos). O modal também tem o checkbox **"Resolve all related reports
+for this user"** (default marcado).
+
+### 3.2 Status de "onboarding incompleto" (ActiveStudents)
+
+**Arquivo:** `src/pages-v2/Campus/ActiveStudents/ActiveStudents.tsx`. Um estudante é exibido como
+**`incomplete`** quando `isOnboarded === false` **ou** possui **menos de 3 interesses**
+(`interestCount < 3`). Caso contrário mantém o `status` do backend.
+
+### 3.3 Reports (ReportSafety)
+
+- **Status (labels da tela):** `Pending review`, `Under evaluation`, `Resolved`, `Dismissed`.
+- **Nota obrigatória:** mudar status para **Resolved** ou **Dismissed** exige nota (via
+  `WriteNoteModal`, não-vazia, máx **500** caracteres). A nota (`adminV2ReportsNoteCreate`) é gravada
+  **antes** da mudança de status (`adminV2ReportsStatusPartialUpdate`). Outros status mudam direto.
+- **Flag/Unflag do item denunciado:** roteia por tipo — `Students`/`Events`/`Ideas`/`Spaces`
+  (`adminV2{Tipo}FlagCreate/UnflagCreate`), com update otimista da lista `["reports"]`.
+- **Banir/Desativar a partir do report:** reutiliza `adminV2StudentsLockSettingsUpdate` e
+  `adminV2StudentsDelete`.
+
+### 3.4 Camada `reportService` (legado / não usado pela tela)
+
+`src/services/reportService.ts` implementa outra convenção de moderação, apontando para endpoints
+**sem `v2`**: `adminReportsList/Detail/StatusPartialUpdate/BanUserCreate/BulkPartialUpdate`, com
+- **Status:** `pending | under_review | resolved | dismissed`
+- **Bulk `action`:** `resolve | dismiss | under_review`
+- **Ban a partir do report:** `{ ban_duration, ban_reason, resolve_related_reports }`
+- **removeUser:** `DELETE /api/admin/users/{id}/remove` com `{ reason, sendEmail }` (default `sendEmail=true`)
+
+> A tela `ReportSafety` **não** usa esse service (usa `adminV2Reports*`). Tratado como **camada
+> antiga**; mantido no repo mas fora do caminho ativo de UI.
+
+---
+
+## 4. Nomes de roles e mapeamentos
+
+**Arquivo:** `src/lib/permissions.ts` (`roleDisplayNameMap`, `displayNameToRoleMap`).
+
+| Nome interno | Nome de exibição |
+|---|---|
+| `super_admin` | Walky Admin |
+| `school_admin` | School Admin |
+| `campus_admin` | Campus Admin |
+| `moderator` | Moderator |
+| `walky_internal` | Walky Internal |
+
+**Allowlist de login** (`src/pages-v2/LoginV2/LoginV2.tsx`) — roles aceitos no painel:
+`super_admin`, `walky_internal`, `school_admin`, `campus_admin`, `editor`, `moderator`, `staff`,
+`viewer`. (Note que `editor`, `staff`, `viewer` **passam no login mas não têm entrada na
+`permissionMatrix`** → cairiam em `noPermissions` para todo recurso mapeado.)
+
+**Roles atribuíveis via `rolesService.assignRole`** (`src/services/rolesService.ts`) — o tipo aceita
+um conjunto maior: `super_admin | school_admin | campus_admin | editor | moderator | staff | viewer |
+student | faculty | parent`. **(não confirmado no admin)** quais são de fato válidos é decidido pelo
+backend.
+
+---
+
+## 5. Regras de sessão e segurança
+
+**Arquivos:** `src/hooks/useAuth.ts`, `src/API/index.ts`, `src/layout-v2/TopbarV2/TopbarV2.tsx`,
+`src/contexts/DeactivatedUserContext.tsx`, `src/pages-v2/ForcePasswordChange/ForcePasswordChange.tsx`.
+
+1. **Fonte de verdade da sessão = `localStorage`** (`token`, `user`). Não há cookie de sessão do lado
+   do app para auth (mas `withCredentials: true` é usado para o cookie de CSRF).
+2. **Token JWT em `Authorization: Bearer`** injetado em toda request pelo interceptor. Se `user` no
+   storage estiver corrompido, `useAuth` limpa `token` + `user`.
+3. **CSRF:** em requests **não-GET** (`!get/head/options`), o interceptor lê o cookie CSRF
+   (`csrf_cookie_rr` → `XSRF-TOKEN` → `csrf_token` → `_csrf`) e o envia em `X-CSRF-Token` **e**
+   `X-XSRF-Token`.
+4. **401 → logout:** o interceptor remove `token` e redireciona a `/login` (se ainda não estiver lá).
+   **Não há refresh token** no admin: o `refresh_token` do login não é persistido e
+   `POST /api/refresh-token` não é chamado.
+5. **403 `ACCOUNT_DEACTIVATED` / `USER_DEACTIVATED` → modal de conta desativada** (bloqueante). Um
+   403 comum de permissão **não** abre o modal.
+6. **Troca forçada de senha:** se `require_password_change` no login, o usuário é levado a
+   `/force-password-change` (nova senha mín. 8, confirmar igual; `currentPassword` vazio por ser reset
+   forçado). A rota é pública mas a página revalida sessão e a flag.
+7. **Sync entre abas:** logout/login numa aba propaga para outras via evento nativo `storage`
+   (`useAuth`), e na mesma aba via evento custom `auth:user-updated`.
+8. **Logout:** remove `token`+`user` (Topbar) — **não** remove `selectedSchool`/`selectedCampus`. O
+   logout de conta desativada remove também `refreshToken`. Ambos usam `window.location.href = "/login"`.
+9. **RBAC é client-side (UX):** `AuthGuard` protege a área autenticada e `PermissionGuard` cada rota;
+   ações inline somem via `can*()`/`fallback="hidden"`. **A autorização real é do backend.**
+10. **Logout de todos os dispositivos** e **2FA** existem em AdministratorSettings
+    (`adminV2SettingsLogoutAllCreate`, `adminProfile2Fa{Enable,Disable}Create`) — a validação/efeito
+    real é do backend. **(não confirmado no admin)**.
+
+> **Nota (segurança):** a base do cliente gerado remove o sufixo `/api` (`baseURL.replace(/\/api\/?$/, "")`)
+> porque rotas admin já incluem `/api/...` e rotas legadas batem na raiz (`/campus`, `/ambassadors`).
+> Ver [workflows.md §T1](./workflows.md#t1-camada-axios-interceptors-csrf-token).
+
+---
+
+## 6. Regras de campus, geofences e ambassadors
+
+**Arquivos:** `src/services/campusService.ts`, `src/services/campusSyncService.ts`,
+`src/pages-v2/CampusBoundary/CampusBoundary.tsx`, `src/services/ambassadorService.ts`,
+`src/components-v2/AddAmbassadorModal/AddAmbassadorModal.tsx`.
+
+### 6.1 Campus
+
+- **Campos do create/update** (`campusService.create/update`): **obrigatórios** `campus_name`,
+  `phone_number`, `address`, `city`, `state`, `zip`, `time_zone`. **Opcionais** `campus_short_name`,
+  `image_url`, `ambassador_ids[]`, `coordinates` (Polygon), `dawn_to_dusk[]`, `is_active` (default `true`).
+- **`campusService.getAll`** trata **404 como lista vazia** (sem erro). O create loga detalhes extras
+  em erro 400 (validação do backend).
+- **Mapeamento** `_id → id` para compat com o frontend.
+
+### 6.2 Geofence (boundary)
+
+- Polígono desenhado no Google Maps precisa de **mínimo 3 vértices**; o anel é **fechado** (primeiro
+  ponto repetido no fim) e salvo como GeoJSON `Polygon` com coords **`[lng, lat]`** (WGS84).
+- **`previewCampusBoundary(id)`** retorna `bounds`, `center`, `area_sqm`/`area_acres`, `search_points`
+  usados no sync de places.
+- **Chave do Google Maps hardcoded** em `CampusBoundary.tsx` (a env `VITE_GOOGLE_MAPS_API_KEY`
+  sugerida no `.env.example` **não é lida**). Ver [integrations.md](./integrations.md).
+
+### 6.3 Sync de places
+
+`campusSyncService`: `syncCampus`, `syncAllCampuses`, `getSyncLogs`, `getCampusesWithSyncStatus`,
+`previewCampusBoundary`. Status de sync: `completed | failed | partial | in_progress`. Cada sync
+reporta `places_added/updated/removed`, `api_calls_used`, `sync_duration_ms`, `errors[]`.
+**(não confirmado no admin)** as regras de quantas chamadas ao Google Places / limites são do backend.
+
+### 6.4 Ambassadors
+
+- Campos do create (`ambassadorService.create`): `name`, `email` (obrigatórios); opcionais `phone`,
+  `student_id`, `is_active` (default `true`), `profile_image_url`, `bio`, `graduation_year`, `major`.
+- **`getAll` é fail-soft** (retorna `[]` em erro); as demais operações propagam erro.
+- No `AddAmbassadorModal`, estudantes são buscados por **nome exato**
+  (`adminV2MembersList({ role:"student", exactMatch:true })`) e cada seleção vira um ambassador com
+  `{ name, email, user_id, school_id, campuses_id[] }`.
+- Ações gated por `canCreate("ambassadors")` / `canDelete("ambassadors")`.
+
+---
+
+## 7. Validações de formulários
+
+Fonte: componentes de cada tela/modal citados.
+
+| Formulário | Campo | Regra | Arquivo |
+|---|---|---|---|
+| Login | email/senha | ambos `required`; role deve estar na allowlist | `LoginV2.tsx` |
+| Force password change | newPassword | `>= 8` chars e `=== confirmPassword` | `ForcePasswordChange.tsx` |
+| Recover — OTP | otp | exatamente **6 dígitos** (`/^\d{6}$/`), trim; máx 6 tentativas (lockout) | `RecoverPasswordV2/VerifyCodeStep.tsx` |
+| Recover — reset | password | `>= 8` e `=== confirm`; erros de backend "Password validation failed" listados | `RecoverPasswordV2/ResetPasswordStep.tsx` |
+| Settings — senha | newPassword | `>= 8`, confirmar igual, `currentPassword` obrigatório | `AdministratorSettings.tsx` |
+| Settings — avatar | avatar | imagem, máx **5MB** | `AdministratorSettings.tsx` |
+| Ban user | reason | **obrigatório** (botão desabilitado se vazio); duração default "1 Day" | `BanUserModal.tsx` |
+| Write note (report) | note | não-vazia; `maxCharacters` **500** | `WriteNoteModal.tsx` |
+| Create member | firstName, lastName, email, role | todos obrigatórios; email formato; role filtrado por hierarquia | `CreateMemberModal.tsx` |
+| Campus | campus_name, phone_number, address, city, state, zip, time_zone | obrigatórios | `campusService.ts` / form da página |
+| Ambassador | name, email | obrigatórios | `ambassadorService.ts` / `AddAmbassadorModal.tsx` |
+
+> Muitas validações são **duplicadas no backend** — o admin faz a validação de UX; o backend rejeita
+> definitivamente. **(não confirmado no admin)** os limites exatos do backend (ex.: política de senha).
+
+---
+
+## 8. Proteção de rotas (route → resource)
+
+**Arquivo:** `src/lib/permissions.ts` (`routeResourceMap`, `canAccessRoute`) + `src/routes/v2Routes.tsx`.
+
+Cada rota mapeada a um recurso é protegida por `PermissionGuard` com `action = 'read'`
+(`fallback="redirect"` → `/dashboard/engagement`).
+
+| Rota | Recurso |
+|---|---|
+| `/dashboard/engagement` | `engagement` |
+| `/dashboard/popular-features` | `popular_features` |
+| `/dashboard/user-interactions` | `user_interactions` |
+| `/dashboard/community` | `community` |
+| `/dashboard/student-safety` | `student_safety` |
+| `/dashboard/student-behavior` | `student_behavior` |
+| `/manage-students/active` | `active_students` |
+| `/manage-students/banned` | `banned_students` |
+| `/manage-students/deactivated` | `inactive_students` |
+| `/manage-students/disengaged` | `disengaged_students` |
+| `/events` · `/events/insights` · `/events/check-in` | `events_manager` · `events_insights` · `events_insights` |
+| `/spaces` · `/spaces/insights` | `spaces_manager` · `spaces_insights` |
+| `/ideas` · `/ideas/insights` | `ideas_manager` · `ideas_insights` |
+| `/report-safety` · `/report-history` | `report_safety` · `report_history` |
+| `/admin/campuses` · `/admin/ambassadors` · `/admin/role-management` | `campuses` · `ambassadors` · `role_management` |
+
+**Regras de `canAccessRoute`:**
+- Rota **sem** mapeamento → **permitida por padrão** (ex.: `/admin/settings` — sem `PermissionGuard`
+  no roteador; qualquer admin autenticado acessa).
+- Rota mapeada → exige `hasPermission(role, resource, 'read')`.
+- `/manage-students/deactivated` mapeia para o recurso **`inactive_students`** (nome interno difere
+  do caminho "deactivated").
+- Rotas do **Playground** (14 visualizações) e o `*` (404) não têm guard de permissão.
+- Redirects legados: `/campuses`, `/ambassadors`, `/role-management` → `/admin/...`.
+
+---
+
+## Cross-links
+
+- [workflows.md](./workflows.md) — fluxos de ponta a ponta com diagramas Mermaid.
+- [overview.md](./overview.md) — propósito, stack, público-alvo, env vars.
+- [integrations.md](./integrations.md) — camada de API e integrações (Google Maps, etc.).
+- [conventions.md](./conventions.md) — convenções de código.
+- Controllers do backend:
+  [admin/admin-students-controller.md](./admin/admin-students-controller.md),
+  [admin/admin-reports-controller.md](./admin/admin-reports-controller.md),
+  [admin/admin-settings-controller.md](./admin/admin-settings-controller.md),
+  [admin/admin-ambassadors-controller.md](./admin/admin-ambassadors-controller.md).

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,61 +1,61 @@
-# Convenções — walky-admin
+# Conventions — walky-admin
 
-> Padrões **reais** do painel administrativo Walky (React 19 + CoreUI 5 + Vite 7).
-> Todos os exemplos abaixo são trechos verdadeiros do código-fonte. Cite sempre paths
-> absolutos ao referenciar arquivos.
+> **Real** patterns of the Walky administrative dashboard (React 19 + CoreUI 5 + Vite 7).
+> All examples below are genuine snippets from the source code. Always cite absolute
+> paths when referencing files.
 
-## Índice
+## Table of Contents
 
-- [1. O sufixo `-v2`](#1-o-sufixo--v2)
-- [2. Nomenclatura de arquivos e símbolos](#2-nomenclatura-de-arquivos-e-símbolos)
-- [3. Componente: pasta `.tsx` + `.css` namespaced](#3-componente-pasta-tsx--css-namespaced)
-- [4. `data-testid` obrigatório (`check:testids`)](#4-data-testid-obrigatório-checktestids)
-- [5. Acessibilidade (`check:a11y`)](#5-acessibilidade-checka11y)
+- [1. The `-v2` suffix](#1-the--v2-suffix)
+- [2. File and symbol naming](#2-file-and-symbol-naming)
+- [3. Component: folder with `.tsx` + namespaced `.css`](#3-component-folder-with-tsx--namespaced-css)
+- [4. Required `data-testid` (`check:testids`)](#4-required-data-testid-checktestids)
+- [5. Accessibility (`check:a11y`)](#5-accessibility-checka11y)
 - [6. Barrel exports (`index.ts`)](#6-barrel-exports-indexts)
-- [7. Camada de services](#7-camada-de-services)
+- [7. Services layer](#7-services-layer)
 - [8. React Query](#8-react-query)
 - [9. Design tokens (CSS variables) + dark mode](#9-design-tokens-css-variables--dark-mode)
-- [10. `PermissionGuard` / `AuthGuard` em rotas](#10-permissionguard--authguard-em-rotas)
-- [11. Logging (nunca `console.*` direto)](#11-logging-nunca-console-direto)
+- [10. `PermissionGuard` / `AuthGuard` on routes](#10-permissionguard--authguard-on-routes)
+- [11. Logging (never `console.*` directly)](#11-logging-never-console-directly)
 
 Cross-links: [development.md](./development.md) · [troubleshooting.md](./troubleshooting.md) · [ai-reference.md](./ai-reference.md)
 
 ---
 
-## 1. O sufixo `-v2`
+## 1. The `-v2` suffix
 
-O app foi migrado para um novo design system. **O código novo vive em pastas com sufixo `-v2`**;
-o código legado (sem sufixo) está em processo de descontinuação. Ao criar algo novo, use sempre a
-variante `-v2`.
+The app was migrated to a new design system. **New code lives in folders with the `-v2` suffix**;
+legacy code (without the suffix) is being phased out. When creating something new, always use the
+`-v2` variant.
 
-| Legado | Atual (usar) |
+| Legacy | Current (use this) |
 |--------|--------------|
 | `src/components/` | `src/components-v2/` |
 | `src/pages/`, `src/views/` | `src/pages-v2/` |
 | `src/layout/` | `src/layout-v2/` |
 | `src/assets/` | `src/assets-v2/` |
 | `src/styles/` | `src/styles-v2/` |
-| rotas antigas | `src/routes/v2Routes.tsx` |
+| old routes | `src/routes/v2Routes.tsx` |
 
-O `App.tsx` monta `V2Routes` como rota default (`/*`) e redireciona paths antigos `/v2/*` para a raiz
-(`src/App.tsx`). As checagens de qualidade (`scripts/check-test-ids.js`, `scripts/check-accessibility.js`)
-**só varrem** `src/pages-v2`, `src/components-v2` e `src/layout-v2`.
+`App.tsx` mounts `V2Routes` as the default route (`/*`) and redirects old `/v2/*` paths to the root
+(`src/App.tsx`). The quality checks (`scripts/check-test-ids.js`, `scripts/check-accessibility.js`)
+**only scan** `src/pages-v2`, `src/components-v2`, and `src/layout-v2`.
 
-## 2. Nomenclatura de arquivos e símbolos
+## 2. File and symbol naming
 
-- **Componentes/páginas**: `PascalCase`. A pasta tem o mesmo nome do componente:
+- **Components/pages**: `PascalCase`. The folder has the same name as the component:
   `src/components-v2/Chip/Chip.tsx`, `src/pages-v2/Events/EventsManager/EventsManager.tsx`.
-- **CSS pareado**: mesmo nome do componente — `Chip.tsx` → `Chip.css`.
-- **Barrel**: cada pasta tem um `index.ts` que reexporta.
-- **Hooks**: `camelCase` com prefixo `use` — `src/hooks/useAuth.ts`, `useDebounce.ts`.
-- **Services**: `camelCase` + sufixo `Service` — `src/services/userService.ts`, `campusService.ts`.
-- **Testes**: um arquivo por fonte, ao lado — `Foo.tsx` → `Foo.test.tsx` (ver [development.md](./development.md#testes)).
-- **Classes CSS**: `kebab-case` prefixado pelo nome do componente (ver seção 3).
+- **Paired CSS**: same name as the component — `Chip.tsx` → `Chip.css`.
+- **Barrel**: each folder has an `index.ts` that re-exports.
+- **Hooks**: `camelCase` with a `use` prefix — `src/hooks/useAuth.ts`, `useDebounce.ts`.
+- **Services**: `camelCase` + `Service` suffix — `src/services/userService.ts`, `campusService.ts`.
+- **Tests**: one file per source, alongside it — `Foo.tsx` → `Foo.test.tsx` (see [development.md](./development.md#testes)).
+- **CSS classes**: `kebab-case` prefixed with the component name (see section 3).
 
-## 3. Componente: pasta `.tsx` + `.css` namespaced
+## 3. Component: folder with `.tsx` + namespaced `.css`
 
-Cada componente é uma pasta com três arquivos: o `.tsx`, o `.css` de mesmo nome e o `index.ts`.
-Não há CSS Modules; o isolamento é feito por **convenção de prefixo** nas classes.
+Each component is a folder with three files: the `.tsx`, the `.css` of the same name, and the
+`index.ts`. There are no CSS Modules; isolation is done by a **prefix convention** on the classes.
 
 ```
 src/components-v2/Chip/
@@ -64,7 +64,7 @@ src/components-v2/Chip/
 └── index.ts      # barrel
 ```
 
-O `.tsx` importa o `.css` diretamente e todas as classes começam com o nome do componente:
+The `.tsx` imports the `.css` directly and every class begins with the component name:
 
 ```tsx
 // src/components-v2/Chip/Chip.tsx
@@ -86,15 +86,15 @@ export const Chip: React.FC<ChipProps> = ({ value, type, className = "" }) => {
 .chip-badge__label { display: block; white-space: pre-line; }
 ```
 
-Páginas seguem o mesmo padrão: `EventsManager.tsx` importa `./EventsManager.css` e usa classes
-`events-manager-*` (`src/pages-v2/Events/EventsManager/`). Sub-componentes de uma página moram em
-`components/` dentro da pasta da feature (ex.: `src/pages-v2/Events/components/EventTable/`).
+Pages follow the same pattern: `EventsManager.tsx` imports `./EventsManager.css` and uses
+`events-manager-*` classes (`src/pages-v2/Events/EventsManager/`). Sub-components of a page live in
+`components/` inside the feature folder (e.g., `src/pages-v2/Events/components/EventTable/`).
 
-## 4. `data-testid` obrigatório (`check:testids`)
+## 4. Required `data-testid` (`check:testids`)
 
-**Todo `<button>`, `<input>` e `<form>`** em `pages-v2`/`components-v2` precisa de `data-testid`.
-O script `scripts/check-test-ids.js` roda no pre-commit e no CI (`.github/workflows/code-quality.yml`)
-e **bloqueia** o commit se faltar.
+**Every `<button>`, `<input>`, and `<form>`** in `pages-v2`/`components-v2` needs a `data-testid`.
+The `scripts/check-test-ids.js` script runs on pre-commit and in CI (`.github/workflows/code-quality.yml`)
+and **blocks** the commit if one is missing.
 
 ```tsx
 // src/pages-v2/Events/EventsManager/EventsManager.tsx
@@ -107,24 +107,24 @@ e **bloqueia** o commit se faltar.
 </button>
 ```
 
-Componentes de UI compartilhados expõem props para propagar o testid ao elemento interativo interno
-(ex.: `FilterDropdown` recebe `testId="event-type-filter"`). Nos testes, prefira consultar por
-role/label/testid — nunca por classe CSS (ver `docs/TESTING.md`).
+Shared UI components expose props to propagate the testid to the inner interactive element (e.g.,
+`FilterDropdown` takes `testId="event-type-filter"`). In tests, prefer querying by
+role/label/testid — never by CSS class (see `docs/TESTING.md`).
 
-## 5. Acessibilidade (`check:a11y`)
+## 5. Accessibility (`check:a11y`)
 
-O `scripts/check-accessibility.js` (WCAG 2.1 AA) roda no pre-commit e no CI, varrendo
-`pages-v2`, `components-v2`, `layout-v2`. Regras aplicadas (violação = commit bloqueado):
+`scripts/check-accessibility.js` (WCAG 2.1 AA) runs on pre-commit and in CI, scanning `pages-v2`,
+`components-v2`, `layout-v2`. Rules applied (violation = commit blocked):
 
-- `<img>` precisa de `alt` ou `aria-hidden="true"`.
-- `<button>` precisa de texto visível **ou** `aria-label`/`aria-labelledby` (botões só-ícone
-  exigem `aria-label`).
-- `<input>`/`<select>` precisam de `aria-label`, `aria-labelledby` ou `id` (para associar `<label>`).
-- Roles de landmark/widget (`region`, `group`, `navigation`, `form`, …) exigem rótulo acessível.
+- `<img>` needs `alt` or `aria-hidden="true"`.
+- `<button>` needs visible text **or** `aria-label`/`aria-labelledby` (icon-only buttons require
+  `aria-label`).
+- `<input>`/`<select>` need `aria-label`, `aria-labelledby`, or `id` (to associate a `<label>`).
+- Landmark/widget roles (`region`, `group`, `navigation`, `form`, …) require an accessible label.
 - `role="radio"` → `aria-checked`; `role="tab"` → `aria-selected`.
 
-Warnings (não bloqueiam): páginas em `pages-v2` deveriam ter landmark `<main>`; componentes com
-`onClick` cujo `.css` não tem `:focus`/`:focus-visible`. Exemplo real de página com `<main>`:
+Warnings (non-blocking): pages in `pages-v2` should have a `<main>` landmark; components with
+`onClick` whose `.css` has no `:focus`/`:focus-visible`. A real example of a page with `<main>`:
 
 ```tsx
 // src/pages-v2/Events/EventsManager/EventsManager.tsx
@@ -133,7 +133,7 @@ return <main className="events-manager-container"> ... </main>;
 
 ## 6. Barrel exports (`index.ts`)
 
-Cada componente/feature exporta via `index.ts`, e há um barrel raiz agregando tudo:
+Each component/feature exports via `index.ts`, and there is a root barrel aggregating everything:
 
 ```ts
 // src/components-v2/Chip/index.ts
@@ -149,21 +149,22 @@ export { PermissionGuard } from "./PermissionGuard";
 export { AuthGuard } from "./AuthGuard";
 ```
 
-Consumidores importam do barrel, não do arquivo interno:
+Consumers import from the barrel, not the inner file:
 
 ```tsx
 import { Pagination, SearchInput, FilterDropdown, NoData } from "../../../components-v2";
 ```
 
-Barrels de feature também reexportam tipos usados fora dela — ex.:
-`src/pages-v2/Events/index.ts` exporta `EventsManager`, `EventsInsights`, `CheckInAnalytics` e os
-tipos `EventData`/`EventType`.
+Feature barrels also re-export types used outside the feature — e.g.,
+`src/pages-v2/Events/index.ts` exports `EventsManager`, `EventsInsights`, `CheckInAnalytics`, and the
+`EventData`/`EventType` types.
 
-## 7. Camada de services
+## 7. Services layer
 
-`src/services/*` encapsula chamadas ao **cliente Swagger gerado** (`apiClient` de `src/API`),
-normaliza a resposta e centraliza logging/erros. Não chame `apiClient` cru em componentes de negócio
-quando um service existir. Estrutura típica: objeto com métodos `async` + `export default`.
+`src/services/*` wraps calls to the **generated Swagger client** (`apiClient` from `src/API`),
+normalizes the response, and centralizes logging/errors. Don't call raw `apiClient` in business
+components when a service exists. Typical structure: an object with `async` methods + `export
+default`.
 
 ```ts
 // src/services/userService.ts
@@ -187,17 +188,17 @@ export const userService = {
 export default userService;
 ```
 
-Convenções: parâmetros/retornos tipados via interfaces; normalização de campos opcionais com `??`/`||`;
-`logger.debug` na entrada/sucesso e `logger.error` + `throw` no catch (para o React Query tratar).
+Conventions: typed parameters/returns via interfaces; normalization of optional fields with `??`/`||`;
+`logger.debug` on entry/success and `logger.error` + `throw` in the catch (so React Query can handle it).
 
 ## 8. React Query
 
-Server state é sempre via `@tanstack/react-query`. O client global (`src/lib/queryClient.ts`) define:
-`staleTime` 5 min, `gcTime` 10 min, `refetchOnWindowFocus: false`, e um `retry` que **não** repete
-4xx (exceto 408), até 3 tentativas; mutations `retry: 1`.
+Server state always goes through `@tanstack/react-query`. The global client (`src/lib/queryClient.ts`)
+defines: `staleTime` 5 min, `gcTime` 10 min, `refetchOnWindowFocus: false`, and a `retry` that does
+**not** repeat 4xx (except 408), up to 3 attempts; mutations `retry: 1`.
 
-Uso em página, com `queryKey` incluindo todos os filtros e contexto de school/campus, e
-`placeholderData: keepPreviousData` para paginação suave:
+Usage in a page, with the `queryKey` including all filters and school/campus context, and
+`placeholderData: keepPreviousData` for smooth pagination:
 
 ```tsx
 // src/pages-v2/Events/EventsManager/EventsManager.tsx
@@ -209,18 +210,18 @@ const { data: eventsData, isLoading } = useQuery({
 });
 ```
 
-Há uma factory de chaves em `queryClient.ts` (`queryKeys.campuses`, `queryKeys.campus(id)`, …) para
-domínios com invalidação. Buscas com input de texto passam por `useDebounce` (`src/hooks/useDebounce.ts`,
-500 ms típico) antes de virar `queryKey`.
+There is a key factory in `queryClient.ts` (`queryKeys.campuses`, `queryKeys.campus(id)`, …) for
+domains with invalidation. Text-input searches pass through `useDebounce` (`src/hooks/useDebounce.ts`,
+typically 500 ms) before becoming a `queryKey`.
 
 ## 9. Design tokens (CSS variables) + dark mode
 
-Convivem **dois** sistemas de tema: os do CoreUI (`data-coreui-theme`) e os tokens **V2** próprios.
+**Two** theme systems coexist: CoreUI's (`data-coreui-theme`) and the custom **V2** tokens.
 
-- Tokens V2 em `src/styles-v2/design-tokens.css` como CSS variables `--v2-*`
+- V2 tokens in `src/styles-v2/design-tokens.css` as `--v2-*` CSS variables
   (`--v2-primary-purple-main: #526ac9`, `--v2-bg-card`, `--v2-text-primary`, `--v2-spacing-16`, …).
-  Origem: Figma "Walky Admin Portal". Importados uma vez em `src/main.tsx`.
-- **Dark mode** sobrescreve os mesmos tokens sob dois seletores:
+  Source: the Figma "Walky Admin Portal". Imported once in `src/main.tsx`.
+- **Dark mode** overrides the same tokens under two selectors:
 
 ```css
 /* src/styles-v2/design-tokens.css */
@@ -228,22 +229,22 @@ Convivem **dois** sistemas de tema: os do CoreUI (`data-coreui-theme`) e os toke
 [data-theme="dark"] { /* redefine --v2-* para o tema escuro */ }
 ```
 
-O `ThemeProvider` (`src/contexts/ThemeProvider.tsx`) inicializa de `localStorage("theme")` ou
-`prefers-color-scheme`, e no toggle seta `data-coreui-theme` + `data-theme` no `<html>`, injeta cores
-`--app-*` e adiciona/remove `body.dark-theme`. O `App.tsx` também alterna `body.dark-mode`.
-No CSS de componentes, **use as variáveis `--v2-*`** em vez de cores hardcoded para herdar dark mode.
+The `ThemeProvider` (`src/contexts/ThemeProvider.tsx`) initializes from `localStorage("theme")` or
+`prefers-color-scheme`, and on toggle sets `data-coreui-theme` + `data-theme` on `<html>`, injects
+`--app-*` colors, and adds/removes `body.dark-theme`. `App.tsx` also toggles `body.dark-mode`.
+In component CSS, **use the `--v2-*` variables** instead of hardcoded colors to inherit dark mode.
 
-## 10. `PermissionGuard` / `AuthGuard` em rotas
+## 10. `PermissionGuard` / `AuthGuard` on routes
 
-RBAC é declarado por rota. Roles: `super_admin`, `school_admin`, `campus_admin`, `moderator`,
-`walky_internal`. A matriz de permissões vive em `src/lib/permissions.ts`
+RBAC is declared per route. Roles: `super_admin`, `school_admin`, `campus_admin`, `moderator`,
+`walky_internal`. The permission matrix lives in `src/lib/permissions.ts`
 (`permissionMatrix[role][resource] → { read, create, update, delete, export, manage }`).
 
-- `AuthGuard` (`src/components-v2/AuthGuard/`) protege toda a árvore autenticada em `App.tsx`:
-  redireciona para `/login` se não autenticado, e **renderiza `null` enquanto `isLoading`** (evita
-  flash de redirect no refresh).
-- `PermissionGuard` (`src/components-v2/PermissionGuard/`) envolve cada rota protegida em
-  `src/routes/v2Routes.tsx`, com `resource` e `fallback="redirect"`:
+- `AuthGuard` (`src/components-v2/AuthGuard/`) protects the entire authenticated tree in `App.tsx`:
+  redirects to `/login` if not authenticated, and **renders `null` while `isLoading`** (avoids a
+  redirect flash on refresh).
+- `PermissionGuard` (`src/components-v2/PermissionGuard/`) wraps each protected route in
+  `src/routes/v2Routes.tsx`, with `resource` and `fallback="redirect"`:
 
 ```tsx
 // src/routes/v2Routes.tsx
@@ -254,14 +255,14 @@ RBAC é declarado por rota. Roles: `super_admin`, `school_admin`, `campus_admin`
 } />
 ```
 
-Em UI inline (botões de ação), use o mesmo guard com `fallback="hidden"` (default) ou o HOC
-`withPermission`. Para checagens imperativas, `usePermissions()` expõe `can/canRead/canUpdate/
-canExport/canCreate/canDelete/canManage` e flags `isSuperAdmin`/`isModerator`/… (`src/hooks/usePermissions.ts`).
+In inline UI (action buttons), use the same guard with `fallback="hidden"` (default) or the
+`withPermission` HOC. For imperative checks, `usePermissions()` exposes `can/canRead/canUpdate/
+canExport/canCreate/canDelete/canManage` and `isSuperAdmin`/`isModerator`/… flags (`src/hooks/usePermissions.ts`).
 
-## 11. Logging (nunca `console.*` direto)
+## 11. Logging (never `console.*` directly)
 
-A regra ESLint `no-console: error` **proíbe** `console.*` no código. Todo log passa por
-`src/lib/logger.ts` (`logger.debug/info/warn/error`). `debug`/`info` só emitem em DEV
-(`import.meta.env.DEV`) para não vazar payloads/PII em produção; `warn`/`error` sempre emitem.
-Vite também remove `console.log/info/debug` no build (`vite.config.ts` → `esbuild.pure`).
-O único arquivo com `console` permitido é o próprio `logger.ts` (via `eslint-disable`).
+The ESLint rule `no-console: error` **forbids** `console.*` in the code. Every log goes through
+`src/lib/logger.ts` (`logger.debug/info/warn/error`). `debug`/`info` only emit in DEV
+(`import.meta.env.DEV`) so as not to leak payloads/PII in production; `warn`/`error` always emit.
+Vite also strips `console.log/info/debug` in the build (`vite.config.ts` → `esbuild.pure`).
+The only file where `console` is allowed is `logger.ts` itself (via `eslint-disable`).

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,267 @@
+# Convenções — walky-admin
+
+> Padrões **reais** do painel administrativo Walky (React 19 + CoreUI 5 + Vite 7).
+> Todos os exemplos abaixo são trechos verdadeiros do código-fonte. Cite sempre paths
+> absolutos ao referenciar arquivos.
+
+## Índice
+
+- [1. O sufixo `-v2`](#1-o-sufixo--v2)
+- [2. Nomenclatura de arquivos e símbolos](#2-nomenclatura-de-arquivos-e-símbolos)
+- [3. Componente: pasta `.tsx` + `.css` namespaced](#3-componente-pasta-tsx--css-namespaced)
+- [4. `data-testid` obrigatório (`check:testids`)](#4-data-testid-obrigatório-checktestids)
+- [5. Acessibilidade (`check:a11y`)](#5-acessibilidade-checka11y)
+- [6. Barrel exports (`index.ts`)](#6-barrel-exports-indexts)
+- [7. Camada de services](#7-camada-de-services)
+- [8. React Query](#8-react-query)
+- [9. Design tokens (CSS variables) + dark mode](#9-design-tokens-css-variables--dark-mode)
+- [10. `PermissionGuard` / `AuthGuard` em rotas](#10-permissionguard--authguard-em-rotas)
+- [11. Logging (nunca `console.*` direto)](#11-logging-nunca-console-direto)
+
+Cross-links: [development.md](./development.md) · [troubleshooting.md](./troubleshooting.md) · [ai-reference.md](./ai-reference.md)
+
+---
+
+## 1. O sufixo `-v2`
+
+O app foi migrado para um novo design system. **O código novo vive em pastas com sufixo `-v2`**;
+o código legado (sem sufixo) está em processo de descontinuação. Ao criar algo novo, use sempre a
+variante `-v2`.
+
+| Legado | Atual (usar) |
+|--------|--------------|
+| `src/components/` | `src/components-v2/` |
+| `src/pages/`, `src/views/` | `src/pages-v2/` |
+| `src/layout/` | `src/layout-v2/` |
+| `src/assets/` | `src/assets-v2/` |
+| `src/styles/` | `src/styles-v2/` |
+| rotas antigas | `src/routes/v2Routes.tsx` |
+
+O `App.tsx` monta `V2Routes` como rota default (`/*`) e redireciona paths antigos `/v2/*` para a raiz
+(`src/App.tsx`). As checagens de qualidade (`scripts/check-test-ids.js`, `scripts/check-accessibility.js`)
+**só varrem** `src/pages-v2`, `src/components-v2` e `src/layout-v2`.
+
+## 2. Nomenclatura de arquivos e símbolos
+
+- **Componentes/páginas**: `PascalCase`. A pasta tem o mesmo nome do componente:
+  `src/components-v2/Chip/Chip.tsx`, `src/pages-v2/Events/EventsManager/EventsManager.tsx`.
+- **CSS pareado**: mesmo nome do componente — `Chip.tsx` → `Chip.css`.
+- **Barrel**: cada pasta tem um `index.ts` que reexporta.
+- **Hooks**: `camelCase` com prefixo `use` — `src/hooks/useAuth.ts`, `useDebounce.ts`.
+- **Services**: `camelCase` + sufixo `Service` — `src/services/userService.ts`, `campusService.ts`.
+- **Testes**: um arquivo por fonte, ao lado — `Foo.tsx` → `Foo.test.tsx` (ver [development.md](./development.md#testes)).
+- **Classes CSS**: `kebab-case` prefixado pelo nome do componente (ver seção 3).
+
+## 3. Componente: pasta `.tsx` + `.css` namespaced
+
+Cada componente é uma pasta com três arquivos: o `.tsx`, o `.css` de mesmo nome e o `index.ts`.
+Não há CSS Modules; o isolamento é feito por **convenção de prefixo** nas classes.
+
+```
+src/components-v2/Chip/
+├── Chip.tsx      # componente
+├── Chip.css      # estilos, classes prefixadas .chip-*
+└── index.ts      # barrel
+```
+
+O `.tsx` importa o `.css` diretamente e todas as classes começam com o nome do componente:
+
+```tsx
+// src/components-v2/Chip/Chip.tsx
+import "./Chip.css";
+
+export const Chip: React.FC<ChipProps> = ({ value, type, className = "" }) => {
+  return (
+    <span className={`chip-badge ${sizeClass} ${className}`.trim()} style={{ ... }}>
+      <span className="chip-badge__label">{displayLabel}</span>
+    </span>
+  );
+};
+```
+
+```css
+/* src/components-v2/Chip/Chip.css — todas as classes prefixadas com .chip-badge */
+.chip-badge { display: inline-flex; border-radius: 999px; font-family: "Lato", sans-serif; }
+.chip-badge--compact { min-height: 28px; }
+.chip-badge__label { display: block; white-space: pre-line; }
+```
+
+Páginas seguem o mesmo padrão: `EventsManager.tsx` importa `./EventsManager.css` e usa classes
+`events-manager-*` (`src/pages-v2/Events/EventsManager/`). Sub-componentes de uma página moram em
+`components/` dentro da pasta da feature (ex.: `src/pages-v2/Events/components/EventTable/`).
+
+## 4. `data-testid` obrigatório (`check:testids`)
+
+**Todo `<button>`, `<input>` e `<form>`** em `pages-v2`/`components-v2` precisa de `data-testid`.
+O script `scripts/check-test-ids.js` roda no pre-commit e no CI (`.github/workflows/code-quality.yml`)
+e **bloqueia** o commit se faltar.
+
+```tsx
+// src/pages-v2/Events/EventsManager/EventsManager.tsx
+<button
+  data-testid="view-list-btn"
+  className={`view-toggle-btn ${viewMode === "list" ? "active" : ""}`}
+  onClick={() => setViewMode("list")}
+>
+  List view
+</button>
+```
+
+Componentes de UI compartilhados expõem props para propagar o testid ao elemento interativo interno
+(ex.: `FilterDropdown` recebe `testId="event-type-filter"`). Nos testes, prefira consultar por
+role/label/testid — nunca por classe CSS (ver `docs/TESTING.md`).
+
+## 5. Acessibilidade (`check:a11y`)
+
+O `scripts/check-accessibility.js` (WCAG 2.1 AA) roda no pre-commit e no CI, varrendo
+`pages-v2`, `components-v2`, `layout-v2`. Regras aplicadas (violação = commit bloqueado):
+
+- `<img>` precisa de `alt` ou `aria-hidden="true"`.
+- `<button>` precisa de texto visível **ou** `aria-label`/`aria-labelledby` (botões só-ícone
+  exigem `aria-label`).
+- `<input>`/`<select>` precisam de `aria-label`, `aria-labelledby` ou `id` (para associar `<label>`).
+- Roles de landmark/widget (`region`, `group`, `navigation`, `form`, …) exigem rótulo acessível.
+- `role="radio"` → `aria-checked`; `role="tab"` → `aria-selected`.
+
+Warnings (não bloqueiam): páginas em `pages-v2` deveriam ter landmark `<main>`; componentes com
+`onClick` cujo `.css` não tem `:focus`/`:focus-visible`. Exemplo real de página com `<main>`:
+
+```tsx
+// src/pages-v2/Events/EventsManager/EventsManager.tsx
+return <main className="events-manager-container"> ... </main>;
+```
+
+## 6. Barrel exports (`index.ts`)
+
+Cada componente/feature exporta via `index.ts`, e há um barrel raiz agregando tudo:
+
+```ts
+// src/components-v2/Chip/index.ts
+export { Chip } from "./Chip";
+export type { ChipProps, ChipType } from "./Chip";
+```
+
+```ts
+// src/components-v2/index.ts (agregador — importe daqui)
+export { Chip } from "./Chip";
+export { FilterDropdown } from "./FilterDropdown";
+export { PermissionGuard } from "./PermissionGuard";
+export { AuthGuard } from "./AuthGuard";
+```
+
+Consumidores importam do barrel, não do arquivo interno:
+
+```tsx
+import { Pagination, SearchInput, FilterDropdown, NoData } from "../../../components-v2";
+```
+
+Barrels de feature também reexportam tipos usados fora dela — ex.:
+`src/pages-v2/Events/index.ts` exporta `EventsManager`, `EventsInsights`, `CheckInAnalytics` e os
+tipos `EventData`/`EventType`.
+
+## 7. Camada de services
+
+`src/services/*` encapsula chamadas ao **cliente Swagger gerado** (`apiClient` de `src/API`),
+normaliza a resposta e centraliza logging/erros. Não chame `apiClient` cru em componentes de negócio
+quando um service existir. Estrutura típica: objeto com métodos `async` + `export default`.
+
+```ts
+// src/services/userService.ts
+import { logger } from "../lib/logger";
+import { apiClient } from "../API";
+
+export const userService = {
+  getUsers: async (params?: UsersListParams): Promise<UsersListResponse> => {
+    try {
+      const response = await apiClient.api.adminUsersList({ ...params });
+      return {
+        users: response.data.users || [],
+        pagination: { page: apiPagination?.page ?? 1, /* ... */ },
+      };
+    } catch (error) {
+      logger.error("❌ Failed to fetch users:", error);
+      throw error;
+    }
+  },
+};
+export default userService;
+```
+
+Convenções: parâmetros/retornos tipados via interfaces; normalização de campos opcionais com `??`/`||`;
+`logger.debug` na entrada/sucesso e `logger.error` + `throw` no catch (para o React Query tratar).
+
+## 8. React Query
+
+Server state é sempre via `@tanstack/react-query`. O client global (`src/lib/queryClient.ts`) define:
+`staleTime` 5 min, `gcTime` 10 min, `refetchOnWindowFocus: false`, e um `retry` que **não** repete
+4xx (exceto 408), até 3 tentativas; mutations `retry: 1`.
+
+Uso em página, com `queryKey` incluindo todos os filtros e contexto de school/campus, e
+`placeholderData: keepPreviousData` para paginação suave:
+
+```tsx
+// src/pages-v2/Events/EventsManager/EventsManager.tsx
+const { data: eventsData, isLoading } = useQuery({
+  queryKey: ["events", currentPage, debouncedSearchQuery, typeFilter, statusFilter,
+             sortBy, sortOrder, selectedSchool?._id, selectedCampus?._id],
+  queryFn: () => apiClient.api.adminV2EventsList({ page: currentPage, limit: 10, /* ... */ }),
+  placeholderData: keepPreviousData,
+});
+```
+
+Há uma factory de chaves em `queryClient.ts` (`queryKeys.campuses`, `queryKeys.campus(id)`, …) para
+domínios com invalidação. Buscas com input de texto passam por `useDebounce` (`src/hooks/useDebounce.ts`,
+500 ms típico) antes de virar `queryKey`.
+
+## 9. Design tokens (CSS variables) + dark mode
+
+Convivem **dois** sistemas de tema: os do CoreUI (`data-coreui-theme`) e os tokens **V2** próprios.
+
+- Tokens V2 em `src/styles-v2/design-tokens.css` como CSS variables `--v2-*`
+  (`--v2-primary-purple-main: #526ac9`, `--v2-bg-card`, `--v2-text-primary`, `--v2-spacing-16`, …).
+  Origem: Figma "Walky Admin Portal". Importados uma vez em `src/main.tsx`.
+- **Dark mode** sobrescreve os mesmos tokens sob dois seletores:
+
+```css
+/* src/styles-v2/design-tokens.css */
+:root[data-coreui-theme="dark"],
+[data-theme="dark"] { /* redefine --v2-* para o tema escuro */ }
+```
+
+O `ThemeProvider` (`src/contexts/ThemeProvider.tsx`) inicializa de `localStorage("theme")` ou
+`prefers-color-scheme`, e no toggle seta `data-coreui-theme` + `data-theme` no `<html>`, injeta cores
+`--app-*` e adiciona/remove `body.dark-theme`. O `App.tsx` também alterna `body.dark-mode`.
+No CSS de componentes, **use as variáveis `--v2-*`** em vez de cores hardcoded para herdar dark mode.
+
+## 10. `PermissionGuard` / `AuthGuard` em rotas
+
+RBAC é declarado por rota. Roles: `super_admin`, `school_admin`, `campus_admin`, `moderator`,
+`walky_internal`. A matriz de permissões vive em `src/lib/permissions.ts`
+(`permissionMatrix[role][resource] → { read, create, update, delete, export, manage }`).
+
+- `AuthGuard` (`src/components-v2/AuthGuard/`) protege toda a árvore autenticada em `App.tsx`:
+  redireciona para `/login` se não autenticado, e **renderiza `null` enquanto `isLoading`** (evita
+  flash de redirect no refresh).
+- `PermissionGuard` (`src/components-v2/PermissionGuard/`) envolve cada rota protegida em
+  `src/routes/v2Routes.tsx`, com `resource` e `fallback="redirect"`:
+
+```tsx
+// src/routes/v2Routes.tsx
+<Route path="events" element={
+  <PermissionGuard resource="events_manager" fallback="redirect">
+    <EventsManager />
+  </PermissionGuard>
+} />
+```
+
+Em UI inline (botões de ação), use o mesmo guard com `fallback="hidden"` (default) ou o HOC
+`withPermission`. Para checagens imperativas, `usePermissions()` expõe `can/canRead/canUpdate/
+canExport/canCreate/canDelete/canManage` e flags `isSuperAdmin`/`isModerator`/… (`src/hooks/usePermissions.ts`).
+
+## 11. Logging (nunca `console.*` direto)
+
+A regra ESLint `no-console: error` **proíbe** `console.*` no código. Todo log passa por
+`src/lib/logger.ts` (`logger.debug/info/warn/error`). `debug`/`info` só emitem em DEV
+(`import.meta.env.DEV`) para não vazar payloads/PII em produção; `warn`/`error` sempre emitem.
+Vite também remove `console.log/info/debug` no build (`vite.config.ts` → `esbuild.pure`).
+O único arquivo com `console` permitido é o próprio `logger.ts` (via `eslint-disable`).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,239 @@
+# Configuração e Deploy — walky-admin
+
+> Como configurar, testar, validar e publicar o painel administrativo Walky
+> (React 19 + CoreUI 5 + Vite 7 + Node ≥ 20). Reflete exatamente o
+> [`package.json`](../package.json), [`vite.config.ts`](../vite.config.ts),
+> [`vitest.config.ts`](../vitest.config.ts), [`vercel.json`](../vercel.json),
+> [`.env.example`](../.env.example) e os workflows em `.github/workflows/`.
+
+Documentos relacionados: [integrations.md](./integrations.md) · [TESTING.md](./TESTING.md) ·
+Contexto do ecossistema: [`../AI_CONTEXT.md`](../AI_CONTEXT.md)
+
+---
+
+## Sumário
+
+- [1. Requisitos](#1-requisitos)
+- [2. Variáveis de ambiente](#2-variáveis-de-ambiente)
+- [3. Scripts do package.json](#3-scripts-do-packagejson)
+- [4. Setup local](#4-setup-local)
+- [5. Build (Vite)](#5-build-vite)
+- [6. Testes (Vitest + RTL + MSW)](#6-testes-vitest--rtl--msw)
+- [7. Checagens de qualidade (test IDs, a11y, lint)](#7-checagens-de-qualidade-test-ids-a11y-lint)
+- [8. Git hooks (Husky + lint-staged)](#8-git-hooks-husky--lint-staged)
+- [9. CI/CD (GitHub Actions)](#9-cicd-github-actions)
+- [10. Deploy (Vercel)](#10-deploy-vercel)
+
+---
+
+## 1. Requisitos
+
+- **Node ≥ 20** — declarado em `package.json` (`"engines": { "node": ">=20.0.0" }`). Os workflows
+  de CI usam Node 20; o build da Vercel usa Node 22 (`vercel.json` → `NODE_VERSION: "22"`).
+- **Gerenciador de pacotes:** `npm` funciona; a CI e os hooks usam **Yarn** (`cache: yarn`,
+  `yarn install --frozen-lockfile`). A build da Vercel usa `npm run build`.
+- Para regenerar tipos (`generate:api`): repositório **`../walky-backend`** clonado ao lado, com
+  `swagger.json` disponível. Ver [integrations.md §3](./integrations.md#3-swagger-typescript-api-geração-de-tipos).
+
+---
+
+## 2. Variáveis de ambiente
+
+Todas prefixadas com `VITE_` (expostas ao client pelo Vite). Fonte: [`.env.example`](../.env.example).
+
+| Variável | Exemplo | Usada no código? | Descrição |
+|---|---|---|---|
+| `VITE_API_BASE_URL` | `https://api.walkyapp.com/api` | **Sim** (`src/API/index.ts`, `src/test/handlers.ts`) | Base da API. Fallback `http://localhost:8080/api`. O cliente gerado remove o sufixo `/api`. |
+| `VITE_APP_NAME` | `Walky Admin` | Não encontrada em `src/` | Nome da aplicação (sugestão do `.env.example`). |
+| `VITE_ENV` | `production` | Não encontrada em `src/` | Ambiente lógico: `development` / `staging` / `production`. |
+| `VITE_GOOGLE_MAPS_API_KEY` | `your_key` | **Não** (comentada no `.env.example`) | A chave do Google Maps está **hardcoded** em `CampusBoundary.tsx` — ver [integrations.md §4](./integrations.md#4-google-maps). |
+| `VITE_SENTRY_DSN` | `your_dsn` | **Não** (comentada no `.env.example`) | Sem integração de Sentry no código — ver [integrations.md §5](./integrations.md#5-sentry). |
+
+Valores de `VITE_API_BASE_URL` por ambiente (comentados no `.env.example`):
+
+- Produção: `https://api.walkyapp.com/api`
+- Staging: `https://staging.walkyapp.com/api`
+- Local: `http://localhost:8081/api` (ou `8080`)
+
+> Na prática, a **única** env var de aplicação lida em `src/` é `VITE_API_BASE_URL` (mais o built-in
+> `import.meta.env.DEV`, usado pelo logger). As demais são placeholders no `.env.example`.
+
+**Setup local:** copie `.env.example` para `.env` e ajuste `VITE_API_BASE_URL`. Na Vercel, defina as
+env vars em *Project Settings → Environment Variables*.
+
+---
+
+## 3. Scripts do package.json
+
+Todos os scripts (fonte: [`package.json`](../package.json)):
+
+| Script | Comando | O que faz |
+|---|---|---|
+| `dev` | `vite` | Dev server (Vite) — porta padrão **5173** (ou próxima livre). |
+| `build` | `tsc -b && vite build` | Type-check (`tsc -b`) e build de produção → `dist/`. |
+| `preview` | `vite preview` | Servidor local para pré-visualizar o build de `dist/`. |
+| `lint` | `eslint .` | ESLint em todo o repo (flat config `eslint.config.js`). |
+| `tsc` | `tsc` | Compilador TypeScript (sem build incremental). |
+| `type-check` | `tsc -b` | Type-check incremental (project references), sem emitir. |
+| `clean` | `./clean-build.sh` | Script de limpeza de build. |
+| `test` | `vitest` | Testes em modo watch (Vitest). Use `test -- --run` para rodar uma vez. |
+| `test:ui` | `vitest --ui` | UI interativa do Vitest. |
+| `test:coverage` | `vitest --coverage` | Testes + relatório de cobertura (v8). |
+| `check:testids` | `node scripts/check-test-ids.js` | Valida `data-testid` em `<button>`, `<input>`, `<form>`. |
+| `check:a11y` | `node scripts/check-accessibility.js` | Checagem de acessibilidade dos componentes. |
+| `check:all` | `check:testids && check:a11y && test -- --run` | Roda os três gates de qualidade em sequência. |
+| `generate:api` | `npx swagger-typescript-api generate -p ../walky-backend/swagger.json -o ./src/API --axios --name WalkyAPI.ts` | Gera cliente/tipos a partir do Swagger do backend. Ver [integrations.md §3](./integrations.md#3-swagger-typescript-api-geração-de-tipos). |
+| `generate:icons` | `node scripts/generate-icons.cjs` | Gera componentes React de ícones a partir dos SVGs em `src/assets-v2/svg` → `src/components-v2/AssetIcon/`. |
+| `generate:images` | `node scripts/generate-images.cjs` | Gera componentes de imagem a partir de PNG/JPEG em `src/assets-v2/images` → `src/components-v2/AssetImage/`. |
+| `prepare` | `husky` | Instala os git hooks do Husky (roda no `install`). |
+
+---
+
+## 4. Setup local
+
+```bash
+# 1. Instalar dependências (Node ≥ 20)
+yarn install          # ou: npm install
+
+# 2. Configurar env
+cp .env.example .env  # ajuste VITE_API_BASE_URL
+
+# 3. (opcional) Regenerar tipos a partir do backend
+yarn generate:api     # requer ../walky-backend/swagger.json
+
+# 4. Rodar em dev
+yarn dev              # http://localhost:5173
+```
+
+---
+
+## 5. Build (Vite)
+
+Config: [`vite.config.ts`](../vite.config.ts).
+
+- **Plugins:** `@vitejs/plugin-react` e `vite-plugin-svgr` (importar SVG como componente via
+  `*.svg?react`; `exportType: "default"`, `ref: true`, `titleProp: true`).
+- **esbuild `pure`:** em builds de produção, remove `console.log/info/debug` (mantém `warn`/`error`).
+- **Saída:** `dist/` (`outDir: "dist"`, `emptyOutDir: true`).
+- **Manual chunks** (code splitting para vendor):
+  - `react-vendor`: `react`, `react-dom`, `react-router-dom`
+  - `coreui`: `@coreui/react`, `@coreui/coreui`, `@coreui/icons-react`, `@coreui/icons`
+  - `charts`: `recharts`
+  - `query`: `@tanstack/react-query`
+
+O `build` roda `tsc -b` antes do `vite build`, então **erros de tipo bloqueiam o build**.
+
+---
+
+## 6. Testes (Vitest + RTL + MSW)
+
+Config: [`vitest.config.ts`](../vitest.config.ts). Documento dedicado: [TESTING.md](./TESTING.md).
+
+- **Runner:** Vitest 4 (`globals: true`, `environment: "jsdom"`, `css: true`).
+- **Setup:** `setupFiles: "./src/test/setup.ts"`.
+- **Alias:** `@` → `./src`.
+- **Biblioteca de componentes:** React Testing Library + `@testing-library/jest-dom` +
+  `@testing-library/user-event`.
+- **Mock de rede:** **MSW** (`msw`). O servidor fica em `src/test/server.ts` (`setupServer(...handlers)`),
+  os handlers padrão em `src/test/handlers.ts`, e o ciclo de vida em `src/test/setup.ts`:
+  - `beforeAll`: `server.listen({ onUnhandledRequest: "error" })` — qualquer request sem handler
+    **falha o teste** (nenhum teste toca a rede real).
+  - `afterEach`: `cleanup()`, `server.resetHandlers()`, limpa `localStorage`/`sessionStorage`, `vi.clearAllMocks()`.
+  - `afterAll`: `server.close()`.
+  - `API_BASE` em `handlers.ts` espelha `src/API/index.ts` (usa `VITE_API_BASE_URL` e remove `/api`).
+- **Polyfills jsdom** (em `setup.ts`): `matchMedia`, `ResizeObserver`, `IntersectionObserver`,
+  `scrollTo`, `scrollIntoView`, `navigator.clipboard` — exigidos por ThemeProvider, recharts,
+  simplebar e componentes CoreUI.
+- **Utilitários:** `src/test/test-utils.tsx` (render com providers) e `src/test/factories.ts`.
+
+**Cobertura** (`test:coverage`): provider `v8`, reporters `text`/`json`/`html`/`lcov`. Exclui
+`node_modules`, `dist`, arquivos de teste/config, `scripts/**`, `src/main.tsx`, o gerado
+`src/API/WalkyAPI.ts`, `*.d.ts` e `**/index.ts`. **Ratchet de thresholds** (só sobe):
+`statements 80` · `branches 65` · `functions 78` · `lines 80`.
+
+```bash
+yarn test               # watch
+yarn test -- --run      # uma execução (usado em CI)
+yarn test:coverage      # com cobertura
+yarn test:ui            # UI do Vitest
+```
+
+---
+
+## 7. Checagens de qualidade (test IDs, a11y, lint)
+
+- **`check:testids`** (`scripts/check-test-ids.js`): garante que `<button>`, `<input>` e `<form>`
+  tenham `data-testid` (testabilidade). Roda no pre-commit.
+- **`check:a11y`** (`scripts/check-accessibility.js`): valida regras de acessibilidade dos componentes.
+- **`lint`** (`eslint .`): ESLint 9 flat config com `typescript-eslint`, `eslint-plugin-react-hooks`
+  e `eslint-plugin-react-refresh`.
+- **`check:all`**: encadeia `check:testids` + `check:a11y` + `test -- --run`.
+
+---
+
+## 8. Git hooks (Husky + lint-staged)
+
+- **Husky** instalado via `prepare: "husky"`. Hook em `.husky/pre-commit` executa, na ordem:
+  1. `yarn build` (bloqueia commit se o build falhar),
+  2. `node scripts/check-test-ids.js`,
+  3. `node scripts/check-accessibility.js`,
+  4. `npx lint-staged`.
+- **lint-staged** (config no `package.json`): para `*.{ts,tsx}` roda
+  `./clean-build.sh` seguido de `eslint --fix` (com `--max-old-space-size=4096`).
+
+---
+
+## 9. CI/CD (GitHub Actions)
+
+Dois workflows em `.github/workflows/` (todos com Node 20, cache `yarn`):
+
+### `test.yml` — "CI"
+- Dispara em `pull_request` e em `push` para `main`/`staging`. Usa `concurrency` para cancelar runs
+  superados no mesmo ref.
+- Instala com `yarn install --frozen-lockfile` (`HUSKY: 0` para pular hooks).
+- **Gate rígido (bloqueia merge):** `yarn test --run` (testes unit/integração).
+- **Gates informativos** (`continue-on-error: true`, não bloqueiam): `type-check`, `lint`,
+  `check:testids`, `check:a11y`.
+
+### `code-quality.yml` — "Code Quality Check"
+- Dispara em `pull_request` para `main`/`develop`/`staging`/`feat/*` e em `push` para
+  `main`/`develop`/`staging`.
+- Quatro jobs paralelos: **Test IDs** (`yarn check:testids`), **Accessibility** (`yarn check:a11y`),
+  **Unit Tests** (`yarn test --run --reporter=verbose`), **Lint** (`yarn lint`).
+
+> Não há workflow de deploy nos Actions — o deploy é feito pela integração Git da **Vercel** (§10).
+
+---
+
+## 10. Deploy (Vercel)
+
+Config: [`vercel.json`](../vercel.json).
+
+```jsonc
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
+  "build": { "env": { "NODE_VERSION": "22" } },
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "vite"
+}
+```
+
+- **Framework:** Vite (detectado automaticamente).
+- **Build:** `npm run build` (→ `tsc -b && vite build`), saída em `dist/`.
+- **Node:** 22 no build da Vercel (o app exige ≥ 20).
+- **SPA routing:** o `rewrites` reescreve **qualquer** rota para `/index.html`, deixando o
+  React Router (v7) resolver a navegação client-side (evita 404 em refresh de rotas internas).
+- **Env vars:** definidas no painel da Vercel (*Project Settings → Environment Variables*) — no
+  mínimo `VITE_API_BASE_URL` para o ambiente correto.
+- **Fluxo:** push no Git → build automática na Vercel → deploy. Preview deployments por PR; produção
+  no branch de produção. Domínio/SSL geridos pela Vercel (ver [README](../README.md#-deploying-to-vercel)).
+
+```mermaid
+flowchart LR
+  DEV["git push / PR"] --> V["Vercel (integração Git)"]
+  V -->|npm run build<br/>Node 22| B["dist/"]
+  B --> CDN["Vercel Edge/CDN"]
+  CDN -->|rewrites → /index.html| SPA["SPA (React Router)"]
+  SPA -->|VITE_API_BASE_URL| API["walky-backend /api"]
+```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,107 +1,107 @@
-# Configuração e Deploy — walky-admin
+# Configuration and Deployment — walky-admin
 
-> Como configurar, testar, validar e publicar o painel administrativo Walky
-> (React 19 + CoreUI 5 + Vite 7 + Node ≥ 20). Reflete exatamente o
+> How to configure, test, validate, and publish the Walky admin panel
+> (React 19 + CoreUI 5 + Vite 7 + Node ≥ 20). Mirrors exactly the
 > [`package.json`](../package.json), [`vite.config.ts`](../vite.config.ts),
 > [`vitest.config.ts`](../vitest.config.ts), [`vercel.json`](../vercel.json),
-> [`.env.example`](../.env.example) e os workflows em `.github/workflows/`.
+> [`.env.example`](../.env.example), and the workflows in `.github/workflows/`.
 
-Documentos relacionados: [integrations.md](./integrations.md) · [TESTING.md](./TESTING.md) ·
-Contexto do ecossistema: [`../AI_CONTEXT.md`](../AI_CONTEXT.md)
+Related documents: [integrations.md](./integrations.md) · [TESTING.md](./TESTING.md) ·
+Ecosystem context: [`../AI_CONTEXT.md`](../AI_CONTEXT.md)
 
 ---
 
-## Sumário
+## Table of Contents
 
-- [1. Requisitos](#1-requisitos)
-- [2. Variáveis de ambiente](#2-variáveis-de-ambiente)
-- [3. Scripts do package.json](#3-scripts-do-packagejson)
-- [4. Setup local](#4-setup-local)
+- [1. Requirements](#1-requisitos)
+- [2. Environment variables](#2-environment-variables)
+- [3. package.json scripts](#3-scripts-do-packagejson)
+- [4. Local setup](#4-setup-local)
 - [5. Build (Vite)](#5-build-vite)
-- [6. Testes (Vitest + RTL + MSW)](#6-testes-vitest--rtl--msw)
-- [7. Checagens de qualidade (test IDs, a11y, lint)](#7-checagens-de-qualidade-test-ids-a11y-lint)
+- [6. Testing (Vitest + RTL + MSW)](#6-testes-vitest--rtl--msw)
+- [7. Quality checks (test IDs, a11y, lint)](#7-checagens-de-qualidade-test-ids-a11y-lint)
 - [8. Git hooks (Husky + lint-staged)](#8-git-hooks-husky--lint-staged)
 - [9. CI/CD (GitHub Actions)](#9-cicd-github-actions)
-- [10. Deploy (Vercel)](#10-deploy-vercel)
+- [10. Deployment (Vercel)](#10-deploy-vercel)
 
 ---
 
-## 1. Requisitos
+## 1. Requirements
 
-- **Node ≥ 20** — declarado em `package.json` (`"engines": { "node": ">=20.0.0" }`). Os workflows
-  de CI usam Node 20; o build da Vercel usa Node 22 (`vercel.json` → `NODE_VERSION: "22"`).
-- **Gerenciador de pacotes:** `npm` funciona; a CI e os hooks usam **Yarn** (`cache: yarn`,
-  `yarn install --frozen-lockfile`). A build da Vercel usa `npm run build`.
-- Para regenerar tipos (`generate:api`): repositório **`../walky-backend`** clonado ao lado, com
-  `swagger.json` disponível. Ver [integrations.md §3](./integrations.md#3-swagger-typescript-api-geração-de-tipos).
+- **Node ≥ 20** — declared in `package.json` (`"engines": { "node": ">=20.0.0" }`). The CI workflows
+  use Node 20; the Vercel build uses Node 22 (`vercel.json` → `NODE_VERSION: "22"`).
+- **Package manager:** `npm` works; CI and the hooks use **Yarn** (`cache: yarn`,
+  `yarn install --frozen-lockfile`). The Vercel build uses `npm run build`.
+- To regenerate types (`generate:api`): the **`../walky-backend`** repository cloned alongside, with
+  `swagger.json` available. See [integrations.md §3](./integrations.md#3-swagger-typescript-api-type-generation).
 
 ---
 
-## 2. Variáveis de ambiente
+## 2. Environment variables
 
-Todas prefixadas com `VITE_` (expostas ao client pelo Vite). Fonte: [`.env.example`](../.env.example).
+All prefixed with `VITE_` (exposed to the client by Vite). Source: [`.env.example`](../.env.example).
 
-| Variável | Exemplo | Usada no código? | Descrição |
+| Variable | Example | Used in code? | Description |
 |---|---|---|---|
-| `VITE_API_BASE_URL` | `https://api.walkyapp.com/api` | **Sim** (`src/API/index.ts`, `src/test/handlers.ts`) | Base da API. Fallback `http://localhost:8080/api`. O cliente gerado remove o sufixo `/api`. |
-| `VITE_APP_NAME` | `Walky Admin` | Não encontrada em `src/` | Nome da aplicação (sugestão do `.env.example`). |
-| `VITE_ENV` | `production` | Não encontrada em `src/` | Ambiente lógico: `development` / `staging` / `production`. |
-| `VITE_GOOGLE_MAPS_API_KEY` | `your_key` | **Não** (comentada no `.env.example`) | A chave do Google Maps está **hardcoded** em `CampusBoundary.tsx` — ver [integrations.md §4](./integrations.md#4-google-maps). |
-| `VITE_SENTRY_DSN` | `your_dsn` | **Não** (comentada no `.env.example`) | Sem integração de Sentry no código — ver [integrations.md §5](./integrations.md#5-sentry). |
+| `VITE_API_BASE_URL` | `https://api.walkyapp.com/api` | **Yes** (`src/API/index.ts`, `src/test/handlers.ts`) | API base URL. Fallback `http://localhost:8080/api`. The generated client strips the `/api` suffix. |
+| `VITE_APP_NAME` | `Walky Admin` | Not found in `src/` | Application name (suggested by `.env.example`). |
+| `VITE_ENV` | `production` | Not found in `src/` | Logical environment: `development` / `staging` / `production`. |
+| `VITE_GOOGLE_MAPS_API_KEY` | `your_key` | **No** (commented out in `.env.example`) | The Google Maps key is **hardcoded** in `CampusBoundary.tsx` — see [integrations.md §4](./integrations.md#4-google-maps). |
+| `VITE_SENTRY_DSN` | `your_dsn` | **No** (commented out in `.env.example`) | No Sentry integration in the code — see [integrations.md §5](./integrations.md#5-sentry). |
 
-Valores de `VITE_API_BASE_URL` por ambiente (comentados no `.env.example`):
+`VITE_API_BASE_URL` values per environment (commented out in `.env.example`):
 
-- Produção: `https://api.walkyapp.com/api`
+- Production: `https://api.walkyapp.com/api`
 - Staging: `https://staging.walkyapp.com/api`
-- Local: `http://localhost:8081/api` (ou `8080`)
+- Local: `http://localhost:8081/api` (or `8080`)
 
-> Na prática, a **única** env var de aplicação lida em `src/` é `VITE_API_BASE_URL` (mais o built-in
-> `import.meta.env.DEV`, usado pelo logger). As demais são placeholders no `.env.example`.
+> In practice, the **only** application env var read in `src/` is `VITE_API_BASE_URL` (plus the built-in
+> `import.meta.env.DEV`, used by the logger). The rest are placeholders in `.env.example`.
 
-**Setup local:** copie `.env.example` para `.env` e ajuste `VITE_API_BASE_URL`. Na Vercel, defina as
-env vars em *Project Settings → Environment Variables*.
+**Local setup:** copy `.env.example` to `.env` and adjust `VITE_API_BASE_URL`. On Vercel, define the
+env vars in *Project Settings → Environment Variables*.
 
 ---
 
-## 3. Scripts do package.json
+## 3. package.json scripts
 
-Todos os scripts (fonte: [`package.json`](../package.json)):
+All scripts (source: [`package.json`](../package.json)):
 
-| Script | Comando | O que faz |
+| Script | Command | What it does |
 |---|---|---|
-| `dev` | `vite` | Dev server (Vite) — porta padrão **5173** (ou próxima livre). |
-| `build` | `tsc -b && vite build` | Type-check (`tsc -b`) e build de produção → `dist/`. |
-| `preview` | `vite preview` | Servidor local para pré-visualizar o build de `dist/`. |
-| `lint` | `eslint .` | ESLint em todo o repo (flat config `eslint.config.js`). |
-| `tsc` | `tsc` | Compilador TypeScript (sem build incremental). |
-| `type-check` | `tsc -b` | Type-check incremental (project references), sem emitir. |
-| `clean` | `./clean-build.sh` | Script de limpeza de build. |
-| `test` | `vitest` | Testes em modo watch (Vitest). Use `test -- --run` para rodar uma vez. |
-| `test:ui` | `vitest --ui` | UI interativa do Vitest. |
-| `test:coverage` | `vitest --coverage` | Testes + relatório de cobertura (v8). |
-| `check:testids` | `node scripts/check-test-ids.js` | Valida `data-testid` em `<button>`, `<input>`, `<form>`. |
-| `check:a11y` | `node scripts/check-accessibility.js` | Checagem de acessibilidade dos componentes. |
-| `check:all` | `check:testids && check:a11y && test -- --run` | Roda os três gates de qualidade em sequência. |
-| `generate:api` | `npx swagger-typescript-api generate -p ../walky-backend/swagger.json -o ./src/API --axios --name WalkyAPI.ts` | Gera cliente/tipos a partir do Swagger do backend. Ver [integrations.md §3](./integrations.md#3-swagger-typescript-api-geração-de-tipos). |
-| `generate:icons` | `node scripts/generate-icons.cjs` | Gera componentes React de ícones a partir dos SVGs em `src/assets-v2/svg` → `src/components-v2/AssetIcon/`. |
-| `generate:images` | `node scripts/generate-images.cjs` | Gera componentes de imagem a partir de PNG/JPEG em `src/assets-v2/images` → `src/components-v2/AssetImage/`. |
-| `prepare` | `husky` | Instala os git hooks do Husky (roda no `install`). |
+| `dev` | `vite` | Dev server (Vite) — default port **5173** (or the next free one). |
+| `build` | `tsc -b && vite build` | Type-check (`tsc -b`) and production build → `dist/`. |
+| `preview` | `vite preview` | Local server to preview the `dist/` build. |
+| `lint` | `eslint .` | ESLint across the whole repo (flat config `eslint.config.js`). |
+| `tsc` | `tsc` | TypeScript compiler (no incremental build). |
+| `type-check` | `tsc -b` | Incremental type-check (project references), no emit. |
+| `clean` | `./clean-build.sh` | Build cleanup script. |
+| `test` | `vitest` | Tests in watch mode (Vitest). Use `test -- --run` to run once. |
+| `test:ui` | `vitest --ui` | Interactive Vitest UI. |
+| `test:coverage` | `vitest --coverage` | Tests + coverage report (v8). |
+| `check:testids` | `node scripts/check-test-ids.js` | Validates `data-testid` on `<button>`, `<input>`, `<form>`. |
+| `check:a11y` | `node scripts/check-accessibility.js` | Accessibility check of the components. |
+| `check:all` | `check:testids && check:a11y && test -- --run` | Runs the three quality gates in sequence. |
+| `generate:api` | `npx swagger-typescript-api generate -p ../walky-backend/swagger.json -o ./src/API --axios --name WalkyAPI.ts` | Generates the client/types from the backend Swagger. See [integrations.md §3](./integrations.md#3-swagger-typescript-api-type-generation). |
+| `generate:icons` | `node scripts/generate-icons.cjs` | Generates React icon components from the SVGs in `src/assets-v2/svg` → `src/components-v2/AssetIcon/`. |
+| `generate:images` | `node scripts/generate-images.cjs` | Generates image components from PNG/JPEG in `src/assets-v2/images` → `src/components-v2/AssetImage/`. |
+| `prepare` | `husky` | Installs the Husky git hooks (runs on `install`). |
 
 ---
 
-## 4. Setup local
+## 4. Local setup
 
 ```bash
-# 1. Instalar dependências (Node ≥ 20)
-yarn install          # ou: npm install
+# 1. Install dependencies (Node ≥ 20)
+yarn install          # or: npm install
 
-# 2. Configurar env
-cp .env.example .env  # ajuste VITE_API_BASE_URL
+# 2. Configure env
+cp .env.example .env  # adjust VITE_API_BASE_URL
 
-# 3. (opcional) Regenerar tipos a partir do backend
-yarn generate:api     # requer ../walky-backend/swagger.json
+# 3. (optional) Regenerate types from the backend
+yarn generate:api     # requires ../walky-backend/swagger.json
 
-# 4. Rodar em dev
+# 4. Run in dev
 yarn dev              # http://localhost:5173
 ```
 
@@ -111,101 +111,101 @@ yarn dev              # http://localhost:5173
 
 Config: [`vite.config.ts`](../vite.config.ts).
 
-- **Plugins:** `@vitejs/plugin-react` e `vite-plugin-svgr` (importar SVG como componente via
+- **Plugins:** `@vitejs/plugin-react` and `vite-plugin-svgr` (import SVG as a component via
   `*.svg?react`; `exportType: "default"`, `ref: true`, `titleProp: true`).
-- **esbuild `pure`:** em builds de produção, remove `console.log/info/debug` (mantém `warn`/`error`).
-- **Saída:** `dist/` (`outDir: "dist"`, `emptyOutDir: true`).
-- **Manual chunks** (code splitting para vendor):
+- **esbuild `pure`:** in production builds, removes `console.log/info/debug` (keeps `warn`/`error`).
+- **Output:** `dist/` (`outDir: "dist"`, `emptyOutDir: true`).
+- **Manual chunks** (vendor code splitting):
   - `react-vendor`: `react`, `react-dom`, `react-router-dom`
   - `coreui`: `@coreui/react`, `@coreui/coreui`, `@coreui/icons-react`, `@coreui/icons`
   - `charts`: `recharts`
   - `query`: `@tanstack/react-query`
 
-O `build` roda `tsc -b` antes do `vite build`, então **erros de tipo bloqueiam o build**.
+`build` runs `tsc -b` before `vite build`, so **type errors block the build**.
 
 ---
 
-## 6. Testes (Vitest + RTL + MSW)
+## 6. Testing (Vitest + RTL + MSW)
 
-Config: [`vitest.config.ts`](../vitest.config.ts). Documento dedicado: [TESTING.md](./TESTING.md).
+Config: [`vitest.config.ts`](../vitest.config.ts). Dedicated document: [TESTING.md](./TESTING.md).
 
 - **Runner:** Vitest 4 (`globals: true`, `environment: "jsdom"`, `css: true`).
 - **Setup:** `setupFiles: "./src/test/setup.ts"`.
 - **Alias:** `@` → `./src`.
-- **Biblioteca de componentes:** React Testing Library + `@testing-library/jest-dom` +
+- **Component library:** React Testing Library + `@testing-library/jest-dom` +
   `@testing-library/user-event`.
-- **Mock de rede:** **MSW** (`msw`). O servidor fica em `src/test/server.ts` (`setupServer(...handlers)`),
-  os handlers padrão em `src/test/handlers.ts`, e o ciclo de vida em `src/test/setup.ts`:
-  - `beforeAll`: `server.listen({ onUnhandledRequest: "error" })` — qualquer request sem handler
-    **falha o teste** (nenhum teste toca a rede real).
-  - `afterEach`: `cleanup()`, `server.resetHandlers()`, limpa `localStorage`/`sessionStorage`, `vi.clearAllMocks()`.
+- **Network mocking:** **MSW** (`msw`). The server lives in `src/test/server.ts` (`setupServer(...handlers)`),
+  the default handlers in `src/test/handlers.ts`, and the lifecycle in `src/test/setup.ts`:
+  - `beforeAll`: `server.listen({ onUnhandledRequest: "error" })` — any request without a handler
+    **fails the test** (no test touches the real network).
+  - `afterEach`: `cleanup()`, `server.resetHandlers()`, clears `localStorage`/`sessionStorage`, `vi.clearAllMocks()`.
   - `afterAll`: `server.close()`.
-  - `API_BASE` em `handlers.ts` espelha `src/API/index.ts` (usa `VITE_API_BASE_URL` e remove `/api`).
-- **Polyfills jsdom** (em `setup.ts`): `matchMedia`, `ResizeObserver`, `IntersectionObserver`,
-  `scrollTo`, `scrollIntoView`, `navigator.clipboard` — exigidos por ThemeProvider, recharts,
-  simplebar e componentes CoreUI.
-- **Utilitários:** `src/test/test-utils.tsx` (render com providers) e `src/test/factories.ts`.
+  - `API_BASE` in `handlers.ts` mirrors `src/API/index.ts` (uses `VITE_API_BASE_URL` and strips `/api`).
+- **jsdom polyfills** (in `setup.ts`): `matchMedia`, `ResizeObserver`, `IntersectionObserver`,
+  `scrollTo`, `scrollIntoView`, `navigator.clipboard` — required by ThemeProvider, recharts,
+  simplebar, and CoreUI components.
+- **Utilities:** `src/test/test-utils.tsx` (render with providers) and `src/test/factories.ts`.
 
-**Cobertura** (`test:coverage`): provider `v8`, reporters `text`/`json`/`html`/`lcov`. Exclui
-`node_modules`, `dist`, arquivos de teste/config, `scripts/**`, `src/main.tsx`, o gerado
-`src/API/WalkyAPI.ts`, `*.d.ts` e `**/index.ts`. **Ratchet de thresholds** (só sobe):
+**Coverage** (`test:coverage`): `v8` provider, `text`/`json`/`html`/`lcov` reporters. Excludes
+`node_modules`, `dist`, test/config files, `scripts/**`, `src/main.tsx`, the generated
+`src/API/WalkyAPI.ts`, `*.d.ts`, and `**/index.ts`. **Threshold ratchet** (can only go up):
 `statements 80` · `branches 65` · `functions 78` · `lines 80`.
 
 ```bash
 yarn test               # watch
-yarn test -- --run      # uma execução (usado em CI)
-yarn test:coverage      # com cobertura
-yarn test:ui            # UI do Vitest
+yarn test -- --run      # single run (used in CI)
+yarn test:coverage      # with coverage
+yarn test:ui            # Vitest UI
 ```
 
 ---
 
-## 7. Checagens de qualidade (test IDs, a11y, lint)
+## 7. Quality checks (test IDs, a11y, lint)
 
-- **`check:testids`** (`scripts/check-test-ids.js`): garante que `<button>`, `<input>` e `<form>`
-  tenham `data-testid` (testabilidade). Roda no pre-commit.
-- **`check:a11y`** (`scripts/check-accessibility.js`): valida regras de acessibilidade dos componentes.
-- **`lint`** (`eslint .`): ESLint 9 flat config com `typescript-eslint`, `eslint-plugin-react-hooks`
-  e `eslint-plugin-react-refresh`.
-- **`check:all`**: encadeia `check:testids` + `check:a11y` + `test -- --run`.
+- **`check:testids`** (`scripts/check-test-ids.js`): ensures that `<button>`, `<input>`, and `<form>`
+  have `data-testid` (testability). Runs on pre-commit.
+- **`check:a11y`** (`scripts/check-accessibility.js`): validates the accessibility rules of the components.
+- **`lint`** (`eslint .`): ESLint 9 flat config with `typescript-eslint`, `eslint-plugin-react-hooks`,
+  and `eslint-plugin-react-refresh`.
+- **`check:all`**: chains `check:testids` + `check:a11y` + `test -- --run`.
 
 ---
 
 ## 8. Git hooks (Husky + lint-staged)
 
-- **Husky** instalado via `prepare: "husky"`. Hook em `.husky/pre-commit` executa, na ordem:
-  1. `yarn build` (bloqueia commit se o build falhar),
+- **Husky** installed via `prepare: "husky"`. The hook in `.husky/pre-commit` runs, in order:
+  1. `yarn build` (blocks the commit if the build fails),
   2. `node scripts/check-test-ids.js`,
   3. `node scripts/check-accessibility.js`,
   4. `npx lint-staged`.
-- **lint-staged** (config no `package.json`): para `*.{ts,tsx}` roda
-  `./clean-build.sh` seguido de `eslint --fix` (com `--max-old-space-size=4096`).
+- **lint-staged** (config in `package.json`): for `*.{ts,tsx}` it runs
+  `./clean-build.sh` followed by `eslint --fix` (with `--max-old-space-size=4096`).
 
 ---
 
 ## 9. CI/CD (GitHub Actions)
 
-Dois workflows em `.github/workflows/` (todos com Node 20, cache `yarn`):
+Two workflows in `.github/workflows/` (all on Node 20, `yarn` cache):
 
 ### `test.yml` — "CI"
-- Dispara em `pull_request` e em `push` para `main`/`staging`. Usa `concurrency` para cancelar runs
-  superados no mesmo ref.
-- Instala com `yarn install --frozen-lockfile` (`HUSKY: 0` para pular hooks).
-- **Gate rígido (bloqueia merge):** `yarn test --run` (testes unit/integração).
-- **Gates informativos** (`continue-on-error: true`, não bloqueiam): `type-check`, `lint`,
+- Triggers on `pull_request` and on `push` to `main`/`staging`. Uses `concurrency` to cancel superseded
+  runs on the same ref.
+- Installs with `yarn install --frozen-lockfile` (`HUSKY: 0` to skip hooks).
+- **Hard gate (blocks merge):** `yarn test --run` (unit/integration tests).
+- **Informational gates** (`continue-on-error: true`, non-blocking): `type-check`, `lint`,
   `check:testids`, `check:a11y`.
 
 ### `code-quality.yml` — "Code Quality Check"
-- Dispara em `pull_request` para `main`/`develop`/`staging`/`feat/*` e em `push` para
+- Triggers on `pull_request` to `main`/`develop`/`staging`/`feat/*` and on `push` to
   `main`/`develop`/`staging`.
-- Quatro jobs paralelos: **Test IDs** (`yarn check:testids`), **Accessibility** (`yarn check:a11y`),
+- Four parallel jobs: **Test IDs** (`yarn check:testids`), **Accessibility** (`yarn check:a11y`),
   **Unit Tests** (`yarn test --run --reporter=verbose`), **Lint** (`yarn lint`).
 
-> Não há workflow de deploy nos Actions — o deploy é feito pela integração Git da **Vercel** (§10).
+> There is no deploy workflow in Actions — deployment is handled by the **Vercel** Git integration (§10).
 
 ---
 
-## 10. Deploy (Vercel)
+## 10. Deployment (Vercel)
 
 Config: [`vercel.json`](../vercel.json).
 
@@ -219,19 +219,19 @@ Config: [`vercel.json`](../vercel.json).
 }
 ```
 
-- **Framework:** Vite (detectado automaticamente).
-- **Build:** `npm run build` (→ `tsc -b && vite build`), saída em `dist/`.
-- **Node:** 22 no build da Vercel (o app exige ≥ 20).
-- **SPA routing:** o `rewrites` reescreve **qualquer** rota para `/index.html`, deixando o
-  React Router (v7) resolver a navegação client-side (evita 404 em refresh de rotas internas).
-- **Env vars:** definidas no painel da Vercel (*Project Settings → Environment Variables*) — no
-  mínimo `VITE_API_BASE_URL` para o ambiente correto.
-- **Fluxo:** push no Git → build automática na Vercel → deploy. Preview deployments por PR; produção
-  no branch de produção. Domínio/SSL geridos pela Vercel (ver [README](../README.md#-deploying-to-vercel)).
+- **Framework:** Vite (auto-detected).
+- **Build:** `npm run build` (→ `tsc -b && vite build`), output in `dist/`.
+- **Node:** 22 in the Vercel build (the app requires ≥ 20).
+- **SPA routing:** the `rewrites` rewrite **any** route to `/index.html`, letting
+  React Router (v7) resolve navigation client-side (avoids 404s when refreshing internal routes).
+- **Env vars:** defined in the Vercel dashboard (*Project Settings → Environment Variables*) — at
+  minimum `VITE_API_BASE_URL` for the correct environment.
+- **Flow:** push to Git → automatic build on Vercel → deploy. Preview deployments per PR; production
+  on the production branch. Domain/SSL managed by Vercel (see [README](../README.md#-deploying-to-vercel)).
 
 ```mermaid
 flowchart LR
-  DEV["git push / PR"] --> V["Vercel (integração Git)"]
+  DEV["git push / PR"] --> V["Vercel (Git integration)"]
   V -->|npm run build<br/>Node 22| B["dist/"]
   B --> CDN["Vercel Edge/CDN"]
   CDN -->|rewrites → /index.html| SPA["SPA (React Router)"]

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,70 +1,70 @@
-# Guia de Desenvolvimento — walky-admin
+# Development Guide — walky-admin
 
-> Como rodar, adicionar telas, regenerar tipos, testar e passar nos checks obrigatórios.
+> How to run, add screens, regenerate types, test, and pass the required checks.
 > Stack: React 19 · TypeScript 5.8 · Vite 7 · CoreUI 5 · React Router 7 · React Query 5 · Vitest 4.
 
-## Índice
+## Table of Contents
 
-- [1. Pré-requisitos](#1-pré-requisitos)
-- [2. Rodar localmente](#2-rodar-localmente)
-- [3. Variáveis de ambiente](#3-variáveis-de-ambiente)
-- [4. Adicionar uma página nova (rota lazy + PermissionGuard)](#4-adicionar-uma-página-nova-rota-lazy--permissionguard)
-- [5. Regenerar tipos da API (`generate:api`)](#5-regenerar-tipos-da-api-generateapi)
-- [6. Testes](#6-testes)
-- [7. Checks obrigatórios (`check:all`)](#7-checks-obrigatórios-checkall)
-- [8. Scripts disponíveis](#8-scripts-disponíveis)
-- [9. Erros comuns](#9-erros-comuns)
+- [1. Prerequisites](#1-prerequisites)
+- [2. Running locally](#2-rodar-localmente)
+- [3. Environment variables](#3-environment-variables)
+- [4. Adding a new page (lazy route + PermissionGuard)](#4-adding-a-new-page-lazy-route--permissionguard)
+- [5. Regenerating API types (`generate:api`)](#5-regenerar-tipos-da-api-generateapi)
+- [6. Testing](#6-testes)
+- [7. Required checks (`check:all`)](#7-required-checks-checkall)
+- [8. Available scripts](#8-available-scripts)
+- [9. Common errors](#9-erros-comuns)
 
 Cross-links: [conventions.md](./conventions.md) · [troubleshooting.md](./troubleshooting.md) · [ai-reference.md](./ai-reference.md) · [TESTING.md](./TESTING.md)
 
 ---
 
-## 1. Pré-requisitos
+## 1. Prerequisites
 
-- **Node ≥ 20** (`package.json` → `engines`; `.nvmrc` = `22`; Vercel usa Node 22).
-- Gerenciador: os scripts do husky/CI usam **yarn**, mas `npm` funciona (o README usa `npm run dev`).
-- Backend (`walky-backend`) rodando localmente para dados reais e para `generate:api`.
+- **Node ≥ 20** (`package.json` → `engines`; `.nvmrc` = `22`; Vercel uses Node 22).
+- Package manager: the husky/CI scripts use **yarn**, but `npm` works too (the README uses `npm run dev`).
+- Backend (`walky-backend`) running locally for real data and for `generate:api`.
 
-## 2. Rodar localmente
+## 2. Running locally
 
 ```bash
-yarn install         # ou npm install
-yarn dev             # Vite dev server em http://localhost:5173
+yarn install         # or npm install
+yarn dev             # Vite dev server at http://localhost:5173
 ```
 
-Aponte para o **backend local**. O backend Walky roda em `8080` ou `8081` (neste ambiente o app móvel
-usa `8080`; o backend também expõe `8081`). O client sempre concatena/remove `/api` conforme a rota
-(ver `src/API/index.ts`), então o `VITE_API_BASE_URL` **deve terminar em `/api`**:
+Point at the **local backend**. The Walky backend runs on `8080` or `8081` (in this environment the
+mobile app uses `8080`; the backend also exposes `8081`). The client always appends/strips `/api`
+depending on the route (see `src/API/index.ts`), so `VITE_API_BASE_URL` **must end in `/api`**:
 
 ```env
 # .env
-VITE_API_BASE_URL=http://localhost:8080/api   # ou :8081/api
+VITE_API_BASE_URL=http://localhost:8080/api   # or :8081/api
 VITE_APP_NAME=Walky Admin
 VITE_ENV=development
 ```
 
-> ⚠️ O `.env` versionado atualmente aponta para **staging** (`https://staging.walkyapp.com/api`).
-> Para desenvolvimento local, troque para `localhost`. Reinicie o `yarn dev` após editar o `.env`
-> (Vite injeta env no boot).
+> ⚠️ Your local `.env` (git-ignored) may point to **staging** (`https://staging.walkyapp.com/api`);
+> the committed `.env.example` defaults to production. For local development, switch it to `localhost`.
+> Restart `yarn dev` after editing `.env` (Vite injects env at boot).
 
-## 3. Variáveis de ambiente
+## 3. Environment variables
 
-| Variável | Obrigatória | Uso |
+| Variable | Required | Usage |
 |----------|-------------|-----|
-| `VITE_API_BASE_URL` | sim | Base do Axios. Prod `https://api.walkyapp.com/api`, staging `https://staging.walkyapp.com/api`, local `http://localhost:8080|8081/api`. Deve terminar em `/api`. |
-| `VITE_APP_NAME` | sim | Nome exibido (`Walky Admin`). |
-| `VITE_ENV` | sim | `development` \| `staging` \| `production`. |
-| `VITE_GOOGLE_MAPS_API_KEY` | opcional | Mapas (geofences de campus). |
-| `VITE_SENTRY_DSN` | opcional | Monitoramento. |
+| `VITE_API_BASE_URL` | yes | Axios base URL. Prod `https://api.walkyapp.com/api`, staging `https://staging.walkyapp.com/api`, local `http://localhost:8080|8081/api`. Must end in `/api`. |
+| `VITE_APP_NAME` | yes | Displayed name (`Walky Admin`). |
+| `VITE_ENV` | yes | `development` \| `staging` \| `production`. |
+| `VITE_GOOGLE_MAPS_API_KEY` | optional | Maps (campus geofences). |
+| `VITE_SENTRY_DSN` | optional | Monitoring. |
 
-Template em `.env.example`. Só variáveis com prefixo `VITE_` chegam ao bundle.
+Template in `.env.example`. Only variables with the `VITE_` prefix reach the bundle.
 
-## 4. Adicionar uma página nova (rota lazy + PermissionGuard)
+## 4. Adding a new page (lazy route + PermissionGuard)
 
-Fluxo real, seguindo o padrão de `src/routes/v2Routes.tsx`.
+The actual flow, following the pattern in `src/routes/v2Routes.tsx`.
 
-**4.1** Crie a pasta da página em `src/pages-v2/<Feature>/<Screen>/` com `Screen.tsx` + `Screen.css`.
-Use `<main className="...">` (a11y) e `data-testid` nos elementos interativos:
+**4.1** Create the page folder at `src/pages-v2/<Feature>/<Screen>/` with `Screen.tsx` + `Screen.css`.
+Use `<main className="...">` (a11y) and `data-testid` on interactive elements:
 
 ```tsx
 // src/pages-v2/Reports/ReportsList/ReportsList.tsx
@@ -74,20 +74,20 @@ export const ReportsList: React.FC = () => {
 };
 ```
 
-**4.2** Exporte no barrel da feature `src/pages-v2/Reports/index.ts`:
+**4.2** Export it from the feature barrel `src/pages-v2/Reports/index.ts`:
 
 ```ts
 export { ReportsList } from "./ReportsList/ReportsList";
 ```
 
-**4.3** Registre a rota em `src/routes/v2Routes.tsx` com `React.lazy` (named export → unwrap para
-`default`) e envolva com `PermissionGuard`:
+**4.3** Register the route in `src/routes/v2Routes.tsx` with `React.lazy` (named export → unwrap to
+`default`) and wrap it with `PermissionGuard`:
 
 ```tsx
 const ReportsList = lazy(() =>
   import("../pages-v2/Reports").then((m) => ({ default: m.ReportsList }))
 );
-// ...dentro de <Route path="/" element={<LayoutV2 />}>
+// ...inside <Route path="/" element={<LayoutV2 />}>
 <Route path="reports" element={
   <PermissionGuard resource="report_history" fallback="redirect">
     <ReportsList />
@@ -95,17 +95,17 @@ const ReportsList = lazy(() =>
 } />
 ```
 
-**4.4** Se a rota tem RBAC próprio, adicione o mapeamento em `src/lib/permissions.ts`:
-inclua o `PermissionResource` no union, defina a linha em cada role de `permissionMatrix`, e registre
-o path em `routeResourceMap` (ex.: `'/reports': 'report_history'`).
+**4.4** If the route has its own RBAC, add the mapping in `src/lib/permissions.ts`:
+include the `PermissionResource` in the union, define the row in each role of `permissionMatrix`, and
+register the path in `routeResourceMap` (e.g., `'/reports': 'report_history'`).
 
-**4.5** Adicione o item de navegação em `src/layout-v2/SidebarV2/SidebarV2.tsx` (array de `label`/`path`).
+**4.5** Add the navigation item in `src/layout-v2/SidebarV2/SidebarV2.tsx` (array of `label`/`path`).
 
-**4.6** Crie o teste `ReportsList.test.tsx` ao lado (ver seção 6).
+**4.6** Create the test `ReportsList.test.tsx` alongside it (see section 6).
 
-## 5. Regenerar tipos da API (`generate:api`)
+## 5. Regenerating API types (`generate:api`)
 
-O cliente HTTP tipado é **gerado** a partir do Swagger do backend — não edite à mão.
+The typed HTTP client is **generated** from the backend Swagger — do not edit it by hand.
 
 ```bash
 yarn generate:api
@@ -113,27 +113,27 @@ yarn generate:api
 #     -o ./src/API --axios --name WalkyAPI.ts
 ```
 
-- **Requer** `../walky-backend/swagger.json` existente (repo backend clonado ao lado). Gere/atualize
-  esse arquivo no backend antes (o backend expõe Swagger em `http://localhost:8081/api-docs/`).
-- Saída: `src/API/WalkyAPI.ts` (+ `Api.ts`, `data-contracts.ts`, `http-client.ts`). Esses arquivos são
-  **isentos** de `no-explicit-any` no ESLint (`eslint.config.js`) e da cobertura (`vitest.config.ts`).
-- Sempre que o contrato do backend mudar, regenere e ajuste os services/páginas consumidores.
-- Consuma via `apiClient` (`src/API/index.ts`), que aplica interceptors de token/CSRF/401/403.
+- **Requires** `../walky-backend/swagger.json` to exist (backend repo cloned alongside). Generate/update
+  that file in the backend first (the backend exposes Swagger at `http://localhost:8081/api-docs/`).
+- Output: `src/API/WalkyAPI.ts` (+ `Api.ts`, `data-contracts.ts`, `http-client.ts`). These files are
+  **exempt** from `no-explicit-any` in ESLint (`eslint.config.js`) and from coverage (`vitest.config.ts`).
+- Whenever the backend contract changes, regenerate and update the consuming services/pages.
+- Consume it via `apiClient` (`src/API/index.ts`), which applies the token/CSRF/401/403 interceptors.
 
-## 6. Testes
+## 6. Testing
 
-Vitest + React Testing Library + MSW. Guia completo em [`docs/TESTING.md`](./TESTING.md).
+Vitest + React Testing Library + MSW. Full guide in [`docs/TESTING.md`](./TESTING.md).
 
 ```bash
 yarn test              # watch
-yarn test --run        # single run (o que o CI usa)
-yarn test:ui           # UI do Vitest
-yarn test:coverage     # cobertura (text + html em /coverage)
+yarn test --run        # single run (what CI uses)
+yarn test:ui           # Vitest UI
+yarn test:coverage     # coverage (text + html in /coverage)
 ```
 
-- **Um teste ao lado da fonte**: `Foo.tsx` → `Foo.test.tsx`.
-- Renderize com `renderWithProviders` (`src/test/test-utils.tsx`) — monta a stack real de providers
-  (QueryClient novo por render, Theme, School, Campus, Dashboard, DeactivatedUser, MemoryRouter):
+- **One test alongside the source**: `Foo.tsx` → `Foo.test.tsx`.
+- Render with `renderWithProviders` (`src/test/test-utils.tsx`) — it mounts the real provider stack
+  (a fresh QueryClient per render, Theme, School, Campus, Dashboard, DeactivatedUser, MemoryRouter):
 
 ```tsx
 import { renderWithProviders, screen } from "@/test/test-utils";
@@ -141,51 +141,51 @@ renderWithProviders(<EventsManager />, { route: "/events" });
 expect(await screen.findByRole("table")).toBeInTheDocument();
 ```
 
-- **MSW**: handlers default em `src/test/handlers.ts` (base = `API_BASE`, derivada de `VITE_API_BASE_URL
-  ?? http://localhost:8080/api`). Override por teste com `server.use(...)`; requests sem mock **falham**
-  o teste de propósito. Factories em `src/test/factories.ts` (`mockUser`, `mockSchool`, `mockCampus`, …).
-- **Auth em teste**: semeie `localStorage` (`token` + `user`) antes de renderizar; é limpo após cada teste.
-- Consulte por role/label/testid, nunca por classe CSS. Cobertura tem *ratchet* em `vitest.config.ts`
-  (só pode subir).
+- **MSW**: default handlers in `src/test/handlers.ts` (base = `API_BASE`, derived from `VITE_API_BASE_URL
+  ?? http://localhost:8080/api`). Override per test with `server.use(...)`; unmocked requests **fail**
+  the test on purpose. Factories in `src/test/factories.ts` (`mockUser`, `mockSchool`, `mockCampus`, …).
+- **Auth in tests**: seed `localStorage` (`token` + `user`) before rendering; it's cleared after each test.
+- Query by role/label/testid, never by CSS class. Coverage has a *ratchet* in `vitest.config.ts`
+  (it can only go up).
 
-## 7. Checks obrigatórios (`check:all`)
+## 7. Required checks (`check:all`)
 
 ```bash
 yarn check:all   # = check:testids && check:a11y && test --run
 ```
 
-Rodam também no **pre-commit** (`.husky/pre-commit`: build → testids → a11y → lint-staged) e no
-**CI** (`.github/workflows/code-quality.yml` e `test.yml`, gatilho em PRs para `main/develop/staging/feat/*`).
+They also run on **pre-commit** (`.husky/pre-commit`: build → testids → a11y → lint-staged) and in
+**CI** (`.github/workflows/code-quality.yml` and `test.yml`, triggered on PRs to `main/develop/staging/feat/*`).
 
-- `yarn check:testids` — `<button>`/`<input>`/`<form>` sem `data-testid` = falha. Ver
-  [conventions.md §4](./conventions.md#4-data-testid-obrigatório-checktestids).
-- `yarn check:a11y` — regras WCAG 2.1 AA. Ver [conventions.md §5](./conventions.md#5-acessibilidade-checka11y).
-- `yarn test -- --run` — suíte Vitest (hard gate no CI).
-- `yarn lint` (ESLint) e `yarn type-check` (`tsc -b`) rodam à parte; `no-console` é **error**.
+- `yarn check:testids` — a `<button>`/`<input>`/`<form>` without `data-testid` = failure. See
+  [conventions.md §4](./conventions.md#4-required-data-testid-checktestids).
+- `yarn check:a11y` — WCAG 2.1 AA rules. See [conventions.md §5](./conventions.md#5-acessibilidade-checka11y).
+- `yarn test -- --run` — Vitest suite (hard gate in CI).
+- `yarn lint` (ESLint) and `yarn type-check` (`tsc -b`) run separately; `no-console` is an **error**.
 
-## 8. Scripts disponíveis
+## 8. Available scripts
 
-| Script | Faz |
+| Script | Does |
 |--------|-----|
 | `dev` | Vite dev server (5173). |
 | `build` | `tsc -b && vite build` → `dist/`. |
-| `preview` | Serve o build. |
-| `lint` | ESLint em todo o repo. |
+| `preview` | Serves the build. |
+| `lint` | ESLint across the whole repo. |
 | `type-check` / `tsc` | Type-check via project references. |
 | `test` / `test:ui` / `test:coverage` | Vitest. |
-| `check:testids` / `check:a11y` / `check:all` | Gates de qualidade. |
-| `generate:api` | Regenera cliente da API do Swagger do backend. |
-| `generate:icons` / `generate:images` | Geram assets (`scripts/generate-*.cjs`). |
+| `check:testids` / `check:a11y` / `check:all` | Quality gates. |
+| `generate:api` | Regenerates the API client from the backend Swagger. |
+| `generate:icons` / `generate:images` | Generate assets (`scripts/generate-*.cjs`). |
 | `clean` | `clean-build.sh`. |
 
-Deploy: **Vercel** (`vercel.json` → `framework: vite`, `outputDirectory: dist`, rewrite SPA de
-`/(.*)` para `/index.html`, `NODE_VERSION: 22`).
+Deploy: **Vercel** (`vercel.json` → `framework: vite`, `outputDirectory: dist`, SPA rewrite from
+`/(.*)` to `/index.html`, `NODE_VERSION: 22`).
 
-## 9. Erros comuns
+## 9. Common errors
 
-- **Sem dados / 401 em loop**: `VITE_API_BASE_URL` errado ou não terminando em `/api`; ou apontando
-  para staging/prod sem token válido. Detalhes em [troubleshooting.md](./troubleshooting.md).
-- **Tipos da API desatualizados**: rode `yarn generate:api` (precisa do `swagger.json` do backend).
-- **Commit bloqueado**: falta `data-testid` ou violação de a11y — rode `yarn check:all` antes.
-- **`console.*` reprovado no lint**: use `logger` de `src/lib/logger.ts`.
-- **Editou `.env` e nada mudou**: reinicie `yarn dev` (Vite injeta env no boot).
+- **No data / 401 loop**: `VITE_API_BASE_URL` is wrong or doesn't end in `/api`; or it points to
+  staging/prod without a valid token. Details in [troubleshooting.md](./troubleshooting.md).
+- **Stale API types**: run `yarn generate:api` (requires the backend `swagger.json`).
+- **Commit blocked**: a missing `data-testid` or an a11y violation — run `yarn check:all` first.
+- **`console.*` rejected by lint**: use the `logger` from `src/lib/logger.ts`.
+- **Edited `.env` and nothing changed**: restart `yarn dev` (Vite injects env at boot).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,191 @@
+# Guia de Desenvolvimento — walky-admin
+
+> Como rodar, adicionar telas, regenerar tipos, testar e passar nos checks obrigatórios.
+> Stack: React 19 · TypeScript 5.8 · Vite 7 · CoreUI 5 · React Router 7 · React Query 5 · Vitest 4.
+
+## Índice
+
+- [1. Pré-requisitos](#1-pré-requisitos)
+- [2. Rodar localmente](#2-rodar-localmente)
+- [3. Variáveis de ambiente](#3-variáveis-de-ambiente)
+- [4. Adicionar uma página nova (rota lazy + PermissionGuard)](#4-adicionar-uma-página-nova-rota-lazy--permissionguard)
+- [5. Regenerar tipos da API (`generate:api`)](#5-regenerar-tipos-da-api-generateapi)
+- [6. Testes](#6-testes)
+- [7. Checks obrigatórios (`check:all`)](#7-checks-obrigatórios-checkall)
+- [8. Scripts disponíveis](#8-scripts-disponíveis)
+- [9. Erros comuns](#9-erros-comuns)
+
+Cross-links: [conventions.md](./conventions.md) · [troubleshooting.md](./troubleshooting.md) · [ai-reference.md](./ai-reference.md) · [TESTING.md](./TESTING.md)
+
+---
+
+## 1. Pré-requisitos
+
+- **Node ≥ 20** (`package.json` → `engines`; `.nvmrc` = `22`; Vercel usa Node 22).
+- Gerenciador: os scripts do husky/CI usam **yarn**, mas `npm` funciona (o README usa `npm run dev`).
+- Backend (`walky-backend`) rodando localmente para dados reais e para `generate:api`.
+
+## 2. Rodar localmente
+
+```bash
+yarn install         # ou npm install
+yarn dev             # Vite dev server em http://localhost:5173
+```
+
+Aponte para o **backend local**. O backend Walky roda em `8080` ou `8081` (neste ambiente o app móvel
+usa `8080`; o backend também expõe `8081`). O client sempre concatena/remove `/api` conforme a rota
+(ver `src/API/index.ts`), então o `VITE_API_BASE_URL` **deve terminar em `/api`**:
+
+```env
+# .env
+VITE_API_BASE_URL=http://localhost:8080/api   # ou :8081/api
+VITE_APP_NAME=Walky Admin
+VITE_ENV=development
+```
+
+> ⚠️ O `.env` versionado atualmente aponta para **staging** (`https://staging.walkyapp.com/api`).
+> Para desenvolvimento local, troque para `localhost`. Reinicie o `yarn dev` após editar o `.env`
+> (Vite injeta env no boot).
+
+## 3. Variáveis de ambiente
+
+| Variável | Obrigatória | Uso |
+|----------|-------------|-----|
+| `VITE_API_BASE_URL` | sim | Base do Axios. Prod `https://api.walkyapp.com/api`, staging `https://staging.walkyapp.com/api`, local `http://localhost:8080|8081/api`. Deve terminar em `/api`. |
+| `VITE_APP_NAME` | sim | Nome exibido (`Walky Admin`). |
+| `VITE_ENV` | sim | `development` \| `staging` \| `production`. |
+| `VITE_GOOGLE_MAPS_API_KEY` | opcional | Mapas (geofences de campus). |
+| `VITE_SENTRY_DSN` | opcional | Monitoramento. |
+
+Template em `.env.example`. Só variáveis com prefixo `VITE_` chegam ao bundle.
+
+## 4. Adicionar uma página nova (rota lazy + PermissionGuard)
+
+Fluxo real, seguindo o padrão de `src/routes/v2Routes.tsx`.
+
+**4.1** Crie a pasta da página em `src/pages-v2/<Feature>/<Screen>/` com `Screen.tsx` + `Screen.css`.
+Use `<main className="...">` (a11y) e `data-testid` nos elementos interativos:
+
+```tsx
+// src/pages-v2/Reports/ReportsList/ReportsList.tsx
+import "./ReportsList.css";
+export const ReportsList: React.FC = () => {
+  return <main className="reports-list-container">{/* ... */}</main>;
+};
+```
+
+**4.2** Exporte no barrel da feature `src/pages-v2/Reports/index.ts`:
+
+```ts
+export { ReportsList } from "./ReportsList/ReportsList";
+```
+
+**4.3** Registre a rota em `src/routes/v2Routes.tsx` com `React.lazy` (named export → unwrap para
+`default`) e envolva com `PermissionGuard`:
+
+```tsx
+const ReportsList = lazy(() =>
+  import("../pages-v2/Reports").then((m) => ({ default: m.ReportsList }))
+);
+// ...dentro de <Route path="/" element={<LayoutV2 />}>
+<Route path="reports" element={
+  <PermissionGuard resource="report_history" fallback="redirect">
+    <ReportsList />
+  </PermissionGuard>
+} />
+```
+
+**4.4** Se a rota tem RBAC próprio, adicione o mapeamento em `src/lib/permissions.ts`:
+inclua o `PermissionResource` no union, defina a linha em cada role de `permissionMatrix`, e registre
+o path em `routeResourceMap` (ex.: `'/reports': 'report_history'`).
+
+**4.5** Adicione o item de navegação em `src/layout-v2/SidebarV2/SidebarV2.tsx` (array de `label`/`path`).
+
+**4.6** Crie o teste `ReportsList.test.tsx` ao lado (ver seção 6).
+
+## 5. Regenerar tipos da API (`generate:api`)
+
+O cliente HTTP tipado é **gerado** a partir do Swagger do backend — não edite à mão.
+
+```bash
+yarn generate:api
+# = npx swagger-typescript-api generate -p ../walky-backend/swagger.json \
+#     -o ./src/API --axios --name WalkyAPI.ts
+```
+
+- **Requer** `../walky-backend/swagger.json` existente (repo backend clonado ao lado). Gere/atualize
+  esse arquivo no backend antes (o backend expõe Swagger em `http://localhost:8081/api-docs/`).
+- Saída: `src/API/WalkyAPI.ts` (+ `Api.ts`, `data-contracts.ts`, `http-client.ts`). Esses arquivos são
+  **isentos** de `no-explicit-any` no ESLint (`eslint.config.js`) e da cobertura (`vitest.config.ts`).
+- Sempre que o contrato do backend mudar, regenere e ajuste os services/páginas consumidores.
+- Consuma via `apiClient` (`src/API/index.ts`), que aplica interceptors de token/CSRF/401/403.
+
+## 6. Testes
+
+Vitest + React Testing Library + MSW. Guia completo em [`docs/TESTING.md`](./TESTING.md).
+
+```bash
+yarn test              # watch
+yarn test --run        # single run (o que o CI usa)
+yarn test:ui           # UI do Vitest
+yarn test:coverage     # cobertura (text + html em /coverage)
+```
+
+- **Um teste ao lado da fonte**: `Foo.tsx` → `Foo.test.tsx`.
+- Renderize com `renderWithProviders` (`src/test/test-utils.tsx`) — monta a stack real de providers
+  (QueryClient novo por render, Theme, School, Campus, Dashboard, DeactivatedUser, MemoryRouter):
+
+```tsx
+import { renderWithProviders, screen } from "@/test/test-utils";
+renderWithProviders(<EventsManager />, { route: "/events" });
+expect(await screen.findByRole("table")).toBeInTheDocument();
+```
+
+- **MSW**: handlers default em `src/test/handlers.ts` (base = `API_BASE`, derivada de `VITE_API_BASE_URL
+  ?? http://localhost:8080/api`). Override por teste com `server.use(...)`; requests sem mock **falham**
+  o teste de propósito. Factories em `src/test/factories.ts` (`mockUser`, `mockSchool`, `mockCampus`, …).
+- **Auth em teste**: semeie `localStorage` (`token` + `user`) antes de renderizar; é limpo após cada teste.
+- Consulte por role/label/testid, nunca por classe CSS. Cobertura tem *ratchet* em `vitest.config.ts`
+  (só pode subir).
+
+## 7. Checks obrigatórios (`check:all`)
+
+```bash
+yarn check:all   # = check:testids && check:a11y && test --run
+```
+
+Rodam também no **pre-commit** (`.husky/pre-commit`: build → testids → a11y → lint-staged) e no
+**CI** (`.github/workflows/code-quality.yml` e `test.yml`, gatilho em PRs para `main/develop/staging/feat/*`).
+
+- `yarn check:testids` — `<button>`/`<input>`/`<form>` sem `data-testid` = falha. Ver
+  [conventions.md §4](./conventions.md#4-data-testid-obrigatório-checktestids).
+- `yarn check:a11y` — regras WCAG 2.1 AA. Ver [conventions.md §5](./conventions.md#5-acessibilidade-checka11y).
+- `yarn test -- --run` — suíte Vitest (hard gate no CI).
+- `yarn lint` (ESLint) e `yarn type-check` (`tsc -b`) rodam à parte; `no-console` é **error**.
+
+## 8. Scripts disponíveis
+
+| Script | Faz |
+|--------|-----|
+| `dev` | Vite dev server (5173). |
+| `build` | `tsc -b && vite build` → `dist/`. |
+| `preview` | Serve o build. |
+| `lint` | ESLint em todo o repo. |
+| `type-check` / `tsc` | Type-check via project references. |
+| `test` / `test:ui` / `test:coverage` | Vitest. |
+| `check:testids` / `check:a11y` / `check:all` | Gates de qualidade. |
+| `generate:api` | Regenera cliente da API do Swagger do backend. |
+| `generate:icons` / `generate:images` | Geram assets (`scripts/generate-*.cjs`). |
+| `clean` | `clean-build.sh`. |
+
+Deploy: **Vercel** (`vercel.json` → `framework: vite`, `outputDirectory: dist`, rewrite SPA de
+`/(.*)` para `/index.html`, `NODE_VERSION: 22`).
+
+## 9. Erros comuns
+
+- **Sem dados / 401 em loop**: `VITE_API_BASE_URL` errado ou não terminando em `/api`; ou apontando
+  para staging/prod sem token válido. Detalhes em [troubleshooting.md](./troubleshooting.md).
+- **Tipos da API desatualizados**: rode `yarn generate:api` (precisa do `swagger.json` do backend).
+- **Commit bloqueado**: falta `data-testid` ou violação de a11y — rode `yarn check:all` antes.
+- **`console.*` reprovado no lint**: use `logger` de `src/lib/logger.ts`.
+- **Editou `.env` e nada mudou**: reinicie `yarn dev` (Vite injeta env no boot).

--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -1,0 +1,269 @@
+# Walky Admin — Estrutura de Pastas
+
+> O que cada diretório importante contém e **por quê**. Foco em `src/`, no significado do sufixo
+> **`-v2`**, e nas fronteiras entre camada de dados, RBAC, UI e tema.
+
+## Índice
+
+- [1. Raiz do repositório](#1-raiz-do-repositório)
+- [2. `src/` — mapa geral](#2-src--mapa-geral)
+- [3. O sufixo `-v2` — por que existe](#3-o-sufixo--v2--por-que-existe)
+- [4. `API/` — cliente gerado por Swagger](#4-api--cliente-gerado-por-swagger)
+- [5. `services/` — service layer](#5-services--service-layer)
+- [6. `lib/` — permissões, query, logger, utils](#6-lib--permissões-query-logger-utils)
+- [7. `contexts/` — estado de UI/seleção](#7-contexts--estado-de-uiseleção)
+- [8. `hooks/` — auth, permissões, filtros, tema](#8-hooks--auth-permissões-filtros-tema)
+- [9. `layout-v2/` — shell (Sidebar + Topbar)](#9-layout-v2--shell-sidebar--topbar)
+- [10. `components-v2/` — biblioteca de componentes](#10-components-v2--biblioteca-de-componentes)
+- [11. `pages-v2/` — as telas](#11-pages-v2--as-telas)
+- [12. `routes/` — mapa de rotas](#12-routes--mapa-de-rotas)
+- [13. `types/` — tipos hand-written](#13-types--tipos-hand-written)
+- [14. `styles-v2/` e `theme.ts`](#14-styles-v2-e-themets)
+- [15. `test/`, `scripts/`, `docs/`](#15-test-scripts-docs)
+- [Cross-links](#cross-links)
+
+---
+
+## 1. Raiz do repositório
+
+| Path | O que é |
+|------|---------|
+| `package.json` | Pacote `admin-panel`; scripts, deps (ver [overview](./overview.md#6-stack-completa-versões-reais-e-o-porquê)). |
+| `vite.config.ts` | Config Vite: plugins react + svgr; `esbuild.pure` remove console.* em prod; `manualChunks` (react-vendor/coreui/charts/query). |
+| `vitest.config.ts` | Config de teste (jsdom, setup, coverage V8 com ratchet, alias `@ → src`). |
+| `tsconfig*.json` | `tsconfig.json` (referências) → `tsconfig.app.json` (app, `strict`, `noUnusedLocals`) + `tsconfig.node.json` (config files). |
+| `eslint.config.js` | ESLint flat config (typescript-eslint + react-hooks/react-refresh). |
+| `.env` / `.env.example` / `.env.template` | Env `VITE_*` (ver overview). |
+| `.nvmrc` | Node **22**. |
+| `vercel.json` | Deploy Vercel: framework vite, SPA rewrite, `NODE_VERSION 22`. |
+| `index.html` | HTML raiz da SPA (monta `#root`). |
+| `clean-build.sh` | Usado no pré-commit (lint-staged) e no script `clean`. |
+| `scripts/` | `generate-icons.cjs`, `generate-images.cjs`, `check-test-ids.js`, `check-accessibility.js`. |
+| `docs/` | Esta documentação + `docs/admin/*` (docs dos controllers do backend) e `docs/TESTING.md`. |
+| `public/`, `dist/`, `coverage/` | Estáticos, build e relatório de cobertura. |
+
+## 2. `src/` — mapa geral
+
+```
+src/
+├── main.tsx            # entry: providers (QueryClient→Theme→School→BrowserRouter→App)
+├── App.tsx             # rotas públicas vs. AuthGuard→V2Routes; Toaster
+├── theme.ts            # getTheme(isDark) → objeto de cores do app
+├── index.css / App.css # CSS base
+├── API/                # cliente HTTP GERADO por Swagger + interceptors (index.ts)
+├── services/           # service layer sobre apiClient (12 services)
+├── lib/                # permissions, queryClient, logger, utils
+├── contexts/           # Theme, School, Campus, Dashboard, DeactivatedUser
+├── hooks/              # useAuth, usePermissions, useCampusFilter, useTheme, ...
+├── types/              # tipos TS hand-written (extensões dos gerados)
+├── routes/             # v2Routes.tsx (lazy routes + PermissionGuard)
+├── layout-v2/          # shell: LayoutV2 + SidebarV2 + TopbarV2
+├── components-v2/      # 50+ componentes reutilizáveis (guards, modais, tabelas, filtros)
+├── pages-v2/           # telas (Dashboard, Campus, Events, Spaces, Ideas, Moderation, Admin, ...)
+├── styles-v2/          # design tokens (CSS vars + .ts), global.css
+├── assets-v2/          # imagens/svg do design V2
+├── assets/             # assets legados (coexistem)
+└── test/               # setup + helpers de teste (Vitest/MSW)
+```
+
+## 3. O sufixo `-v2` — por que existe
+
+O `-v2` marca um **redesign completo da camada de UI**, feito **sem** reescrever a arquitetura de
+dados. A divisão é nítida:
+
+| Com `-v2` (camada de UI redesenhada) | Sem `-v2` (fundação preservada / genérica) |
+|---|---|
+| `components-v2/`, `pages-v2/`, `layout-v2/`, `styles-v2/`, `assets-v2/` | `API/`, `services/`, `lib/`, `contexts/`, `hooks/`, `types/`, `routes/`, `test/`, `assets/` |
+
+Ou seja: a **apresentação** (componentes, telas, layout, estilos, assets do Figma) foi refeita numa
+nova geração V2, enquanto **cliente HTTP, services, contexts, hooks, permissões e tipos** continuam
+compartilhados/estáveis. Sinais no código que confirmam a migração:
+
+- `App.tsx` redireciona paths legados `/v2/*` para a raiz (`V2RedirectHandler`) — os caminhos novos
+  viraram o padrão e o prefixo `/v2` antigo é reescrito.
+- `assets/` (legado) **coexiste** com `assets-v2/` (novo, com `README.md`, `images/`, `svg/`).
+- `routes/v2Routes.tsx` (o único arquivo de rotas ativo) monta tudo dentro de `layout-v2`.
+
+> Regra prática ao contribuir: **UI nova vai em `*-v2`**; lógica de dados/estado vai nos diretórios
+> sem sufixo.
+
+## 4. `API/` — cliente gerado por Swagger
+
+`src/API/` — a fronteira HTTP com o backend. Ver detalhes em
+[architecture §4](./architecture.md#4-camada-de-dados-axios-gerado--services--react-query).
+
+| Arquivo | Conteúdo |
+|---------|----------|
+| `WalkyAPI.ts` | **Gerado** (`swagger-typescript-api`, ~15k linhas): classe `Api` (endpoints tipados) + `HttpClient`. `// @ts-nocheck`. |
+| `Api.ts`, `Admin.ts`, `Users.ts`, `Auth.ts`, `Analytics.ts`, `Ambassadors.ts`, `Audit.ts`, `Age.ts` | Módulos gerados (agrupamentos de endpoints por domínio). |
+| `data-contracts.ts` | **Gerado**: interfaces de dados (Chat, Message, Idea, ...). |
+| `http-client.ts` | **Gerado**: wrapper Axios base (default `baseURL` `http://localhost:8081`). |
+| `index.ts` | **Hand-written**: instancia `apiClient`, remove `/api` do baseURL, aplica interceptors (Bearer, CSRF, 401→login, 403 desativação). Exporta `apiClient` (e um `API` axios cru). |
+
+**Não editar os arquivos gerados** — rode `npm run generate:api` (lê `../walky-backend/swagger.json`).
+
+## 5. `services/` — service layer
+
+`src/services/` — 12 módulos entre o `apiClient` gerado e as telas. Cada um: importa `apiClient` de
+`../API`, chama endpoints, normaliza a resposta, loga via `logger`.
+
+| Service | Responsabilidade | Endpoint exemplo |
+|---------|------------------|------------------|
+| `userService.ts` | Lista/gerencia usuários (paginação, filtros de escola/campus/role); tipo `UserWithRoles`. | `adminUsersList` |
+| `campusService.ts` | Lista/cria/atualiza campuses; mapeia `_id→id`. | `campusesList` |
+| `schoolService.ts` | Escolas; define/re-exporta o tipo `School`. | lista de escolas |
+| `ambassadorService.ts` | Embaixadores (CRUD parcial). | `ambassadors.ambassadorsList` (namespace legado) |
+| `analyticsService.ts` | Social health, wellbeing, KPIs, alertas dos dashboards. | `adminCampusMetricsSocialHealthList` |
+| `reportService.ts` | Denúncias (filtro por status/tipo) e usuários banidos. | `adminReportsList` |
+| `rolesService.ts` | Roles, permissões, atribuição de role. | `adminRolesList` |
+| `interestService.ts` | Interesses. | — |
+| `placeService.ts` | Places/Spaces. | — |
+| `placeTypeService.ts` | Tipos de place. | — |
+| `lockedUsersService.ts` | Usuários bloqueados. | — |
+| `campusSyncService.ts` | Sincronização de dados de campus. | — |
+
+## 6. `lib/` — permissões, query, logger, utils
+
+`src/lib/` — fundação transversal (não-UI).
+
+| Arquivo | Papel |
+|---------|-------|
+| `permissions.ts` | **RBAC**: tipos `RoleName`/`PermissionResource`/`PermissionAction`, `permissionMatrix` (5 roles × ~24 recursos × 6 ações), helpers (`hasPermission`, `canAccessRoute`, `getAssignableRoles`), mapas de display name. Fonte da verdade do controle de acesso no cliente. Ver [architecture §5.3](./architecture.md#53-matriz-de-permissões). |
+| `queryClient.ts` | `QueryClient` do React Query (staleTime 5min, gcTime 10min, retry sem 4xx exceto 408) + `queryKeys` factory. |
+| `logger.ts` | Wrapper de console: `debug`/`info` só em dev; `warn`/`error` sempre. Evita vazar PII em prod. |
+| `utils/` | `dateUtils.ts`, `errors.ts`, `nameUtils.ts` (+ testes). Utilidades puras. |
+| `permissions.test.ts`, `queryClient.test.ts` | Testes das peças críticas. |
+
+## 7. `contexts/` — estado de UI/seleção
+
+`src/contexts/` — React Context para estado que **não** é dado remoto (esse fica no React Query).
+
+| Arquivo | Estado / função |
+|---------|-----------------|
+| `SchoolContext.tsx` | Escola selecionada (persistida em `localStorage`), lista disponível. Multi-tenant. |
+| `CampusContext.tsx` | Campus selecionado (persistido), lista disponível. Tipo `Campus`. |
+| `DashboardContext.tsx` | `timePeriod` dos dashboards (default `"month"`). |
+| `DeactivatedUserContext.tsx` | Flag de conta desativada + `handleLogout`; expõe `triggerDeactivatedModal()` (setter global usado pelos interceptors, fora do React). |
+| `ThemeContext.ts` + `ThemeProvider.tsx` | Tema (dark/light) — ver [§14](#14-styles-v2-e-themets). |
+| `index.ts` | Barrel de exports. |
+
+## 8. `hooks/` — auth, permissões, filtros, tema
+
+`src/hooks/`
+
+| Hook | Papel |
+|------|-------|
+| `useAuth.ts` | Lê `token`/`user` do `localStorage`; sync entre abas (evento `storage` + `auth:user-updated`); `isAuthenticated`, `hasRole`, `updateUser`. |
+| `usePermissions.ts` | Envolve `lib/permissions`: `can/canRead/canUpdate/canExport/...` + flags `isSuperAdmin/...`. |
+| `useCampusFilter.ts` | Interceptor que injeta `campus_id` nas requests do campus selecionado (GET params / body). |
+| `useSchoolFilter.ts` | Análogo para escola. |
+| `useTheme.ts` | Acessa o `ThemeContext`. |
+| `useDashboardPrefetch.ts` | Prefetch de dados de dashboard. |
+| `useDebounce.ts` / `useMediaQuery.ts` / `useToolTip.ts` | Utilitários de UI (+ testes). |
+| `index.ts` | Barrel. |
+
+## 9. `layout-v2/` — shell (Sidebar + Topbar)
+
+`src/layout-v2/` — o "casco" das telas autenticadas (renderizado por `v2Routes` em torno do
+`<Outlet/>`).
+
+| Arquivo | Papel |
+|---------|-------|
+| `LayoutV2.tsx` | Compõe `SidebarV2` + `TopbarV2` + `<Outlet/>`; controla visibilidade responsiva da sidebar (auto-fecha ≤992px, fecha ao trocar de rota no mobile); monta o `DeactivatedUserModal`. |
+| `SidebarV2/SidebarV2.tsx` | Navegação. **Filtra itens por permissão** via `usePermissions().canRead(resource)`: item sem permissão some; submenu vazio remove o pai. |
+| `TopbarV2/TopbarV2.tsx` | Seletores de **escola/campus** (`useSchool`/`useCampus`, buscando via `apiClient`), toggle de tema, logout. |
+
+## 10. `components-v2/` — biblioteca de componentes
+
+`src/components-v2/` — ~50 componentes reutilizáveis (exportados por `index.ts`). Categorias:
+
+- **Guards:** `AuthGuard`, `PermissionGuard` (+ HOC `withPermission`) — ver
+  [architecture §5.2](./architecture.md#52-guards).
+- **Filtros/busca:** `FilterBar`, `FilterDropdown`, `MultiSelectFilterDropdown`, `SearchInput`,
+  `StatusDropdown`, `ActionDropdown`.
+- **Tabela/lista:** `Pagination`, `NoData`, `SkeletonLoader`, `LastUpdated`, `CopyableId`, `Chip`,
+  `Divider`, `Drawer`, `BoundaryAvatar`.
+- **Export/gráficos:** `ExportButton` (CSV/PDF), `StackedBarChart`.
+- **Modais (muitos):** de usuário (`BanUserModal`, `UnbanUserModal`, `ActivateUserModal`,
+  `DeactivateUserModal`, `DeleteAccountModal`, `StudentProfileModal`, `SendPasswordResetModal`,
+  `LogoutAllDevicesModal`, `WriteNoteModal`), de moderação (`FlagModal`, `FlagUserModal`,
+  `UnflagModal`, `ReportDetailModal`, `ReportDetailsModal`), de conteúdo (`EventDetailsModal`,
+  `SpaceDetailsModal`, `IdeaDetailsModal`, `ScheduledEventsModal`, `ChangeCategoryModal`,
+  `SeeAllInterestsModal`), de admin/roles (`CreateMemberModal`, `RemoveMemberModal`,
+  `ChangeRoleModal`, `RolePermissionsModal`, `AddAmbassadorModal`, `DeleteAmbassadorModal`),
+  genéricos (`DeleteModal`, `UnsavedChangesModal`, `DeactivatedUserModal`).
+- **Assets/toast:** `AssetIcon`, `AssetImage`, `CustomToast`, `utils`.
+
+## 11. `pages-v2/` — as telas
+
+`src/pages-v2/` — cada rota de [v2Routes](../src/routes/v2Routes.tsx) tem sua tela aqui. Subpastas
+frequentemente têm `components/` locais + barril `index.ts`.
+
+```
+pages-v2/
+├── Dashboard/            # 6 dashboards + components/
+│   ├── Engagement/  PopularFeatures/  UserInteractions/
+│   ├── Community/  StudentSafety/  StudentBehavior/
+├── Campus/               # ActiveStudents, BannedStudents,
+│                         #   DeactivatedStudents, DisengagedStudents
+├── CampusBoundary/       # componente de geofence/limite de campus
+├── Events/               # EventsManager, EventsInsights, CheckInAnalytics
+├── Spaces/               # SpacesManager, SpacesInsights
+├── Ideas/                # IdeasManager, IdeasInsights
+├── Moderation/           # ReportSafety, ReportHistory
+├── Admin/                # AdministratorSettings, Ambassadors,
+│                         #   Campuses, RoleManagement (+ index.ts)
+├── Playground/           # 14 visualizações experimentais (Interest* + ActiveUsers*, Three.js)
+├── LoginV2/              # login (2FA/OTP, force-password-change) + LoginV2.css
+├── RecoverPasswordV2/    # RecoverPasswordV2 + VerifyCodeStep + ResetPasswordStep
+└── ForcePasswordChange/  # troca forçada de senha no 1º login
+```
+
+> Nota: `Dashboard` expõe os 6 painéis via export default; `Campus`, `Events`, `Spaces`, `Ideas`,
+> `Moderation`, `Admin` usam exports nomeados de barris (desembrulhados em `v2Routes` com
+> `.then(m => ({ default: m.Name }))`).
+
+## 12. `routes/` — mapa de rotas
+
+`src/routes/v2Routes.tsx` — único arquivo de rotas ativo. Monta `<LayoutV2/>` com as telas
+**lazy-loaded**, cada uma envolvida por `<PermissionGuard resource="..." fallback="redirect">`.
+Também provê `CampusProvider` + `DashboardProvider` e trata redirects de paths legados
+(`/campuses → /admin/campuses`, etc.). Ver [architecture §3](./architecture.md#3-roteamento-react-router-v7--lazy).
+
+## 13. `types/` — tipos hand-written
+
+`src/types/` — tipos TS **escritos à mão** que estendem/combinam os gerados: `ambassador.ts`,
+`analytics.ts`, `api.ts`, `campus.ts`, `place.ts`, `placeType.ts`, `report.ts`, `role.ts`. Os
+services (`services/*`) unem esses tipos com os de `API/data-contracts.ts`/`WalkyAPI.ts` para
+entregar às telas a forma que elas esperam.
+
+## 14. `styles-v2/` e `theme.ts`
+
+`src/styles-v2/` — sistema de estilo dual (CoreUI + tokens V2):
+
+| Arquivo | Conteúdo |
+|---------|----------|
+| `design-tokens.css` / `design-tokens.ts` | Tokens (spacing, cornerRadius, colors, ...) auto-gerados do Figma — CSS vars e versão TS. |
+| `theme-variables.css` | Variáveis de tema (light/dark). |
+| `ThemeComponents.css` | Estilos de componentes temáticos. |
+| `global.css` | Estilos globais. |
+
+`src/theme.ts` — `getTheme(isDark)` retorna o objeto de cores consumido por
+[`ThemeProvider`](../src/contexts/ThemeProvider.tsx), que aplica `data-coreui-theme` + `data-theme` +
+CSS vars `--app-*` no `<html>`/`<body>`. Ver [architecture §7](./architecture.md#7-tema-e-design-tokens).
+
+## 15. `test/`, `scripts/`, `docs/`
+
+- `src/test/` — `setup.ts` (setup do Vitest/Testing Library) e helpers; MSW para mock de rede. Testes
+  ficam ao lado do código (`*.test.ts[x]`).
+- `scripts/` — `check-test-ids.js` (exige `data-testid`), `check-accessibility.js` (a11y),
+  `generate-icons.cjs`, `generate-images.cjs`.
+- `docs/` — esta documentação (`overview`, `architecture`, `folder-structure`), além de `docs/admin/`
+  (referência dos controllers do backend) e `docs/TESTING.md`.
+
+---
+
+## Cross-links
+
+- [Visão geral](./overview.md) — propósito, público, stack.
+- [Arquitetura](./architecture.md) — fluxo de dados, RBAC, decisões.

--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -1,203 +1,203 @@
-# Walky Admin — Estrutura de Pastas
+# Walky Admin — Folder Structure
 
-> O que cada diretório importante contém e **por quê**. Foco em `src/`, no significado do sufixo
-> **`-v2`**, e nas fronteiras entre camada de dados, RBAC, UI e tema.
+> What each important directory contains and **why**. Focused on `src/`, on the meaning of the
+> **`-v2`** suffix, and on the boundaries between the data layer, RBAC, UI, and theme.
 
-## Índice
+## Table of Contents
 
-- [1. Raiz do repositório](#1-raiz-do-repositório)
-- [2. `src/` — mapa geral](#2-src--mapa-geral)
-- [3. O sufixo `-v2` — por que existe](#3-o-sufixo--v2--por-que-existe)
-- [4. `API/` — cliente gerado por Swagger](#4-api--cliente-gerado-por-swagger)
+- [1. Repository root](#1-repository-root)
+- [2. `src/` — general map](#2-src--general-map)
+- [3. The `-v2` suffix — why it exists](#3-the--v2-suffix--why-it-exists)
+- [4. `API/` — Swagger-generated client](#4-api--swagger-generated-client)
 - [5. `services/` — service layer](#5-services--service-layer)
-- [6. `lib/` — permissões, query, logger, utils](#6-lib--permissões-query-logger-utils)
-- [7. `contexts/` — estado de UI/seleção](#7-contexts--estado-de-uiseleção)
-- [8. `hooks/` — auth, permissões, filtros, tema](#8-hooks--auth-permissões-filtros-tema)
+- [6. `lib/` — permissions, query, logger, utils](#6-lib--permissions-query-logger-utils)
+- [7. `contexts/` — UI/selection state](#7-contexts--uiselection-state)
+- [8. `hooks/` — auth, permissions, filters, theme](#8-hooks--auth-permissions-filters-theme)
 - [9. `layout-v2/` — shell (Sidebar + Topbar)](#9-layout-v2--shell-sidebar--topbar)
-- [10. `components-v2/` — biblioteca de componentes](#10-components-v2--biblioteca-de-componentes)
-- [11. `pages-v2/` — as telas](#11-pages-v2--as-telas)
-- [12. `routes/` — mapa de rotas](#12-routes--mapa-de-rotas)
-- [13. `types/` — tipos hand-written](#13-types--tipos-hand-written)
-- [14. `styles-v2/` e `theme.ts`](#14-styles-v2-e-themets)
+- [10. `components-v2/` — component library](#10-components-v2--component-library)
+- [11. `pages-v2/` — the screens](#11-pages-v2--the-screens)
+- [12. `routes/` — route map](#12-routes--route-map)
+- [13. `types/` — hand-written types](#13-types--hand-written-types)
+- [14. `styles-v2/` and `theme.ts`](#14-styles-v2-and-themets)
 - [15. `test/`, `scripts/`, `docs/`](#15-test-scripts-docs)
 - [Cross-links](#cross-links)
 
 ---
 
-## 1. Raiz do repositório
+## 1. Repository root
 
-| Path | O que é |
+| Path | What it is |
 |------|---------|
-| `package.json` | Pacote `admin-panel`; scripts, deps (ver [overview](./overview.md#6-stack-completa-versões-reais-e-o-porquê)). |
-| `vite.config.ts` | Config Vite: plugins react + svgr; `esbuild.pure` remove console.* em prod; `manualChunks` (react-vendor/coreui/charts/query). |
-| `vitest.config.ts` | Config de teste (jsdom, setup, coverage V8 com ratchet, alias `@ → src`). |
-| `tsconfig*.json` | `tsconfig.json` (referências) → `tsconfig.app.json` (app, `strict`, `noUnusedLocals`) + `tsconfig.node.json` (config files). |
+| `package.json` | The `admin-panel` package; scripts, deps (see [overview](./overview.md#6-full-stack-actual-versions-and-the-rationale)). |
+| `vite.config.ts` | Vite config: react + svgr plugins; `esbuild.pure` strips console.* in prod; `manualChunks` (react-vendor/coreui/charts/query). |
+| `vitest.config.ts` | Test config (jsdom, setup, V8 coverage with ratchet, `@ → src` alias). |
+| `tsconfig*.json` | `tsconfig.json` (references) → `tsconfig.app.json` (app, `strict`, `noUnusedLocals`) + `tsconfig.node.json` (config files). |
 | `eslint.config.js` | ESLint flat config (typescript-eslint + react-hooks/react-refresh). |
-| `.env` / `.env.example` / `.env.template` | Env `VITE_*` (ver overview). |
+| `.env` / `.env.example` / `.env.template` | `VITE_*` env vars (see overview). |
 | `.nvmrc` | Node **22**. |
-| `vercel.json` | Deploy Vercel: framework vite, SPA rewrite, `NODE_VERSION 22`. |
-| `index.html` | HTML raiz da SPA (monta `#root`). |
-| `clean-build.sh` | Usado no pré-commit (lint-staged) e no script `clean`. |
+| `vercel.json` | Vercel deploy: vite framework, SPA rewrite, `NODE_VERSION 22`. |
+| `index.html` | Root HTML of the SPA (mounts `#root`). |
+| `clean-build.sh` | Used in the pre-commit hook (lint-staged) and in the `clean` script. |
 | `scripts/` | `generate-icons.cjs`, `generate-images.cjs`, `check-test-ids.js`, `check-accessibility.js`. |
-| `docs/` | Esta documentação + `docs/admin/*` (docs dos controllers do backend) e `docs/TESTING.md`. |
-| `public/`, `dist/`, `coverage/` | Estáticos, build e relatório de cobertura. |
+| `docs/` | This documentation + `docs/admin/*` (backend controller docs) and `docs/TESTING.md`. |
+| `public/`, `dist/`, `coverage/` | Static assets, build output, and coverage report. |
 
-## 2. `src/` — mapa geral
+## 2. `src/` — general map
 
 ```
 src/
 ├── main.tsx            # entry: providers (QueryClient→Theme→School→BrowserRouter→App)
-├── App.tsx             # rotas públicas vs. AuthGuard→V2Routes; Toaster
-├── theme.ts            # getTheme(isDark) → objeto de cores do app
-├── index.css / App.css # CSS base
-├── API/                # cliente HTTP GERADO por Swagger + interceptors (index.ts)
-├── services/           # service layer sobre apiClient (12 services)
+├── App.tsx             # public routes vs. AuthGuard→V2Routes; Toaster
+├── theme.ts            # getTheme(isDark) → app color object
+├── index.css / App.css # base CSS
+├── API/                # Swagger-GENERATED HTTP client + interceptors (index.ts)
+├── services/           # service layer over apiClient (12 services)
 ├── lib/                # permissions, queryClient, logger, utils
 ├── contexts/           # Theme, School, Campus, Dashboard, DeactivatedUser
 ├── hooks/              # useAuth, usePermissions, useCampusFilter, useTheme, ...
-├── types/              # tipos TS hand-written (extensões dos gerados)
+├── types/              # hand-written TS types (extensions of the generated ones)
 ├── routes/             # v2Routes.tsx (lazy routes + PermissionGuard)
 ├── layout-v2/          # shell: LayoutV2 + SidebarV2 + TopbarV2
-├── components-v2/      # 50+ componentes reutilizáveis (guards, modais, tabelas, filtros)
-├── pages-v2/           # telas (Dashboard, Campus, Events, Spaces, Ideas, Moderation, Admin, ...)
+├── components-v2/      # 52 reusable components (guards, modals, tables, filters)
+├── pages-v2/           # screens (Dashboard, Campus, Events, Spaces, Ideas, Moderation, Admin, ...)
 ├── styles-v2/          # design tokens (CSS vars + .ts), global.css
-├── assets-v2/          # imagens/svg do design V2
-├── assets/             # assets legados (coexistem)
-└── test/               # setup + helpers de teste (Vitest/MSW)
+├── assets-v2/          # V2 design images/svg
+├── assets/             # legacy assets (coexist)
+└── test/               # setup + test helpers (Vitest/MSW)
 ```
 
-## 3. O sufixo `-v2` — por que existe
+## 3. The `-v2` suffix — why it exists
 
-O `-v2` marca um **redesign completo da camada de UI**, feito **sem** reescrever a arquitetura de
-dados. A divisão é nítida:
+The `-v2` marks a **complete redesign of the UI layer**, done **without** rewriting the data
+architecture. The split is clean:
 
-| Com `-v2` (camada de UI redesenhada) | Sem `-v2` (fundação preservada / genérica) |
+| With `-v2` (redesigned UI layer) | Without `-v2` (preserved / generic foundation) |
 |---|---|
 | `components-v2/`, `pages-v2/`, `layout-v2/`, `styles-v2/`, `assets-v2/` | `API/`, `services/`, `lib/`, `contexts/`, `hooks/`, `types/`, `routes/`, `test/`, `assets/` |
 
-Ou seja: a **apresentação** (componentes, telas, layout, estilos, assets do Figma) foi refeita numa
-nova geração V2, enquanto **cliente HTTP, services, contexts, hooks, permissões e tipos** continuam
-compartilhados/estáveis. Sinais no código que confirmam a migração:
+In other words: the **presentation** (components, screens, layout, styles, Figma assets) was rebuilt
+as a new V2 generation, while the **HTTP client, services, contexts, hooks, permissions, and types**
+remain shared/stable. Signals in the code that confirm the migration:
 
-- `App.tsx` redireciona paths legados `/v2/*` para a raiz (`V2RedirectHandler`) — os caminhos novos
-  viraram o padrão e o prefixo `/v2` antigo é reescrito.
-- `assets/` (legado) **coexiste** com `assets-v2/` (novo, com `README.md`, `images/`, `svg/`).
-- `routes/v2Routes.tsx` (o único arquivo de rotas ativo) monta tudo dentro de `layout-v2`.
+- `App.tsx` redirects legacy `/v2/*` paths to the root (`V2RedirectHandler`) — the new paths became
+  the standard and the old `/v2` prefix is rewritten.
+- `assets/` (legacy) **coexists** with `assets-v2/` (new, with `README.md`, `images/`, `svg/`).
+- `routes/v2Routes.tsx` (the only active routes file) mounts everything inside `layout-v2`.
 
-> Regra prática ao contribuir: **UI nova vai em `*-v2`**; lógica de dados/estado vai nos diretórios
-> sem sufixo.
+> Practical rule when contributing: **new UI goes in `*-v2`**; data/state logic goes in the
+> unsuffixed directories.
 
-## 4. `API/` — cliente gerado por Swagger
+## 4. `API/` — Swagger-generated client
 
-`src/API/` — a fronteira HTTP com o backend. Ver detalhes em
-[architecture §4](./architecture.md#4-camada-de-dados-axios-gerado--services--react-query).
+`src/API/` — the HTTP boundary with the backend. See details in
+[architecture §4](./architecture.md#4-data-layer-generated-axios--services--react-query).
 
-| Arquivo | Conteúdo |
+| File | Contents |
 |---------|----------|
-| `WalkyAPI.ts` | **Gerado** (`swagger-typescript-api`, ~15k linhas): classe `Api` (endpoints tipados) + `HttpClient`. `// @ts-nocheck`. |
-| `Api.ts`, `Admin.ts`, `Users.ts`, `Auth.ts`, `Analytics.ts`, `Ambassadors.ts`, `Audit.ts`, `Age.ts` | Módulos gerados (agrupamentos de endpoints por domínio). |
-| `data-contracts.ts` | **Gerado**: interfaces de dados (Chat, Message, Idea, ...). |
-| `http-client.ts` | **Gerado**: wrapper Axios base (default `baseURL` `http://localhost:8081`). |
-| `index.ts` | **Hand-written**: instancia `apiClient`, remove `/api` do baseURL, aplica interceptors (Bearer, CSRF, 401→login, 403 desativação). Exporta `apiClient` (e um `API` axios cru). |
+| `WalkyAPI.ts` | **Generated** (`swagger-typescript-api`, ~15k lines): the `Api` class (typed endpoints) + `HttpClient`. `// @ts-nocheck`. |
+| `Api.ts`, `Admin.ts`, `Users.ts`, `Auth.ts`, `Analytics.ts`, `Ambassadors.ts`, `Audit.ts`, `Age.ts` | Generated modules (endpoint groupings by domain). |
+| `data-contracts.ts` | **Generated**: data interfaces (Chat, Message, Idea, ...). |
+| `http-client.ts` | **Generated**: base Axios wrapper (default `baseURL` `http://localhost:8081`). |
+| `index.ts` | **Hand-written**: instantiates `apiClient`, strips `/api` from the baseURL, applies interceptors (Bearer, CSRF, 401→login, 403 deactivation). Exports `apiClient` (and a raw `API` axios). |
 
-**Não editar os arquivos gerados** — rode `npm run generate:api` (lê `../walky-backend/swagger.json`).
+**Do not edit the generated files** — run `npm run generate:api` (reads `../walky-backend/swagger.json`).
 
 ## 5. `services/` — service layer
 
-`src/services/` — 12 módulos entre o `apiClient` gerado e as telas. Cada um: importa `apiClient` de
-`../API`, chama endpoints, normaliza a resposta, loga via `logger`.
+`src/services/` — 12 modules between the generated `apiClient` and the screens. Each one: imports
+`apiClient` from `../API`, calls endpoints, normalizes the response, logs via `logger`.
 
-| Service | Responsabilidade | Endpoint exemplo |
+| Service | Responsibility | Example endpoint |
 |---------|------------------|------------------|
-| `userService.ts` | Lista/gerencia usuários (paginação, filtros de escola/campus/role); tipo `UserWithRoles`. | `adminUsersList` |
-| `campusService.ts` | Lista/cria/atualiza campuses; mapeia `_id→id`. | `campusesList` |
-| `schoolService.ts` | Escolas; define/re-exporta o tipo `School`. | lista de escolas |
-| `ambassadorService.ts` | Embaixadores (CRUD parcial). | `ambassadors.ambassadorsList` (namespace legado) |
-| `analyticsService.ts` | Social health, wellbeing, KPIs, alertas dos dashboards. | `adminCampusMetricsSocialHealthList` |
-| `reportService.ts` | Denúncias (filtro por status/tipo) e usuários banidos. | `adminReportsList` |
-| `rolesService.ts` | Roles, permissões, atribuição de role. | `adminRolesList` |
-| `interestService.ts` | Interesses. | — |
+| `userService.ts` | Lists/manages users (pagination, school/campus/role filters); `UserWithRoles` type. | `adminUsersList` |
+| `campusService.ts` | Lists/creates/updates campuses; maps `_id→id`. | `campusesList` |
+| `schoolService.ts` | Schools; defines/re-exports the `School` type. | school list |
+| `ambassadorService.ts` | Ambassadors (partial CRUD). | `ambassadors.ambassadorsList` (legacy namespace) |
+| `analyticsService.ts` | Social health, wellbeing, KPIs, dashboard alerts. | `adminCampusMetricsSocialHealthList` |
+| `reportService.ts` | Reports (filter by status/type) and banned users. | `adminReportsList` |
+| `rolesService.ts` | Roles, permissions, role assignment. | `adminRolesList` |
+| `interestService.ts` | Interests. | — |
 | `placeService.ts` | Places/Spaces. | — |
-| `placeTypeService.ts` | Tipos de place. | — |
-| `lockedUsersService.ts` | Usuários bloqueados. | — |
-| `campusSyncService.ts` | Sincronização de dados de campus. | — |
+| `placeTypeService.ts` | Place types. | — |
+| `lockedUsersService.ts` | Locked users. | — |
+| `campusSyncService.ts` | Campus data synchronization. | — |
 
-## 6. `lib/` — permissões, query, logger, utils
+## 6. `lib/` — permissions, query, logger, utils
 
-`src/lib/` — fundação transversal (não-UI).
+`src/lib/` — the cross-cutting (non-UI) foundation.
 
-| Arquivo | Papel |
+| File | Role |
 |---------|-------|
-| `permissions.ts` | **RBAC**: tipos `RoleName`/`PermissionResource`/`PermissionAction`, `permissionMatrix` (5 roles × ~24 recursos × 6 ações), helpers (`hasPermission`, `canAccessRoute`, `getAssignableRoles`), mapas de display name. Fonte da verdade do controle de acesso no cliente. Ver [architecture §5.3](./architecture.md#53-matriz-de-permissões). |
-| `queryClient.ts` | `QueryClient` do React Query (staleTime 5min, gcTime 10min, retry sem 4xx exceto 408) + `queryKeys` factory. |
-| `logger.ts` | Wrapper de console: `debug`/`info` só em dev; `warn`/`error` sempre. Evita vazar PII em prod. |
-| `utils/` | `dateUtils.ts`, `errors.ts`, `nameUtils.ts` (+ testes). Utilidades puras. |
-| `permissions.test.ts`, `queryClient.test.ts` | Testes das peças críticas. |
+| `permissions.ts` | **RBAC**: `RoleName`/`PermissionResource`/`PermissionAction` types, `permissionMatrix` (5 roles × ~24 resources × 6 actions), helpers (`hasPermission`, `canAccessRoute`, `getAssignableRoles`), display-name maps. Source of truth for client-side access control. See [architecture §5.3](./architecture.md#53-permission-matrix). |
+| `queryClient.ts` | React Query `QueryClient` (staleTime 5min, gcTime 10min, no retry on 4xx except 408) + `queryKeys` factory. |
+| `logger.ts` | Console wrapper: `debug`/`info` only in dev; `warn`/`error` always. Avoids leaking PII in prod. |
+| `utils/` | `dateUtils.ts`, `errors.ts`, `nameUtils.ts` (+ tests). Pure utilities. |
+| `permissions.test.ts`, `queryClient.test.ts` | Tests for the critical pieces. |
 
-## 7. `contexts/` — estado de UI/seleção
+## 7. `contexts/` — UI/selection state
 
-`src/contexts/` — React Context para estado que **não** é dado remoto (esse fica no React Query).
+`src/contexts/` — React Context for state that is **not** remote data (that lives in React Query).
 
-| Arquivo | Estado / função |
+| File | State / function |
 |---------|-----------------|
-| `SchoolContext.tsx` | Escola selecionada (persistida em `localStorage`), lista disponível. Multi-tenant. |
-| `CampusContext.tsx` | Campus selecionado (persistido), lista disponível. Tipo `Campus`. |
-| `DashboardContext.tsx` | `timePeriod` dos dashboards (default `"month"`). |
-| `DeactivatedUserContext.tsx` | Flag de conta desativada + `handleLogout`; expõe `triggerDeactivatedModal()` (setter global usado pelos interceptors, fora do React). |
-| `ThemeContext.ts` + `ThemeProvider.tsx` | Tema (dark/light) — ver [§14](#14-styles-v2-e-themets). |
-| `index.ts` | Barrel de exports. |
+| `SchoolContext.tsx` | Selected school (persisted to `localStorage`), available list. Multi-tenant. |
+| `CampusContext.tsx` | Selected campus (persisted), available list. `Campus` type. |
+| `DashboardContext.tsx` | The dashboards' `timePeriod` (default `"month"`). |
+| `DeactivatedUserContext.tsx` | Deactivated-account flag + `handleLogout`; exposes `triggerDeactivatedModal()` (a global setter used by the interceptors, outside React). |
+| `ThemeContext.ts` + `ThemeProvider.tsx` | Theme (dark/light) — see [§14](#14-styles-v2-and-themets). |
+| `index.ts` | Barrel of exports. |
 
-## 8. `hooks/` — auth, permissões, filtros, tema
+## 8. `hooks/` — auth, permissions, filters, theme
 
 `src/hooks/`
 
-| Hook | Papel |
+| Hook | Role |
 |------|-------|
-| `useAuth.ts` | Lê `token`/`user` do `localStorage`; sync entre abas (evento `storage` + `auth:user-updated`); `isAuthenticated`, `hasRole`, `updateUser`. |
-| `usePermissions.ts` | Envolve `lib/permissions`: `can/canRead/canUpdate/canExport/...` + flags `isSuperAdmin/...`. |
-| `useCampusFilter.ts` | Interceptor que injeta `campus_id` nas requests do campus selecionado (GET params / body). |
-| `useSchoolFilter.ts` | Análogo para escola. |
-| `useTheme.ts` | Acessa o `ThemeContext`. |
-| `useDashboardPrefetch.ts` | Prefetch de dados de dashboard. |
-| `useDebounce.ts` / `useMediaQuery.ts` / `useToolTip.ts` | Utilitários de UI (+ testes). |
+| `useAuth.ts` | Reads `token`/`user` from `localStorage`; cross-tab sync (`storage` + `auth:user-updated` events); `isAuthenticated`, `hasRole`, `updateUser`. |
+| `usePermissions.ts` | Wraps `lib/permissions`: `can/canRead/canUpdate/canExport/...` + `isSuperAdmin/...` flags. |
+| `useCampusFilter.ts` | **Defined but not wired up.** Intended as an interceptor that would inject `campus_id` into the selected campus's requests (GET params / body). It is never invoked; in practice `campus_id` is passed explicitly per query. See [architecture §6](./architecture.md#6-multi-tenant-school-and-campus). |
+| `useSchoolFilter.ts` | Analogous to `useCampusFilter` (for school) — also defined but not wired up. |
+| `useTheme.ts` | Accesses `ThemeContext`. |
+| `useDashboardPrefetch.ts` | Dashboard data prefetch — defined but not currently wired up. |
+| `useDebounce.ts` / `useMediaQuery.ts` / `useToolTip.ts` | UI utilities (+ tests). |
 | `index.ts` | Barrel. |
 
 ## 9. `layout-v2/` — shell (Sidebar + Topbar)
 
-`src/layout-v2/` — o "casco" das telas autenticadas (renderizado por `v2Routes` em torno do
+`src/layout-v2/` — the "shell" of the authenticated screens (rendered by `v2Routes` around the
 `<Outlet/>`).
 
-| Arquivo | Papel |
+| File | Role |
 |---------|-------|
-| `LayoutV2.tsx` | Compõe `SidebarV2` + `TopbarV2` + `<Outlet/>`; controla visibilidade responsiva da sidebar (auto-fecha ≤992px, fecha ao trocar de rota no mobile); monta o `DeactivatedUserModal`. |
-| `SidebarV2/SidebarV2.tsx` | Navegação. **Filtra itens por permissão** via `usePermissions().canRead(resource)`: item sem permissão some; submenu vazio remove o pai. |
-| `TopbarV2/TopbarV2.tsx` | Seletores de **escola/campus** (`useSchool`/`useCampus`, buscando via `apiClient`), toggle de tema, logout. |
+| `LayoutV2.tsx` | Composes `SidebarV2` + `TopbarV2` + `<Outlet/>`; controls the sidebar's responsive visibility (auto-closes ≤992px, closes on route change on mobile); mounts the `DeactivatedUserModal`. |
+| `SidebarV2/SidebarV2.tsx` | Navigation. **Filters items by permission** via `usePermissions().canRead(resource)`: an item without permission disappears; an empty submenu removes its parent. |
+| `TopbarV2/TopbarV2.tsx` | **School/campus** selectors (`useSchool`/`useCampus`, fetching via `apiClient`), theme toggle, logout. |
 
-## 10. `components-v2/` — biblioteca de componentes
+## 10. `components-v2/` — component library
 
-`src/components-v2/` — ~50 componentes reutilizáveis (exportados por `index.ts`). Categorias:
+`src/components-v2/` — 52 reusable components (exported from `index.ts`). Categories:
 
-- **Guards:** `AuthGuard`, `PermissionGuard` (+ HOC `withPermission`) — ver
+- **Guards:** `AuthGuard`, `PermissionGuard` (+ `withPermission` HOC) — see
   [architecture §5.2](./architecture.md#52-guards).
-- **Filtros/busca:** `FilterBar`, `FilterDropdown`, `MultiSelectFilterDropdown`, `SearchInput`,
+- **Filters/search:** `FilterBar`, `FilterDropdown`, `MultiSelectFilterDropdown`, `SearchInput`,
   `StatusDropdown`, `ActionDropdown`.
-- **Tabela/lista:** `Pagination`, `NoData`, `SkeletonLoader`, `LastUpdated`, `CopyableId`, `Chip`,
+- **Table/list:** `Pagination`, `NoData`, `SkeletonLoader`, `LastUpdated`, `CopyableId`, `Chip`,
   `Divider`, `Drawer`, `BoundaryAvatar`.
-- **Export/gráficos:** `ExportButton` (CSV/PDF), `StackedBarChart`.
-- **Modais (muitos):** de usuário (`BanUserModal`, `UnbanUserModal`, `ActivateUserModal`,
+- **Export/charts:** `ExportButton` (CSV/PDF), `StackedBarChart`.
+- **Modals (many):** user (`BanUserModal`, `UnbanUserModal`, `ActivateUserModal`,
   `DeactivateUserModal`, `DeleteAccountModal`, `StudentProfileModal`, `SendPasswordResetModal`,
-  `LogoutAllDevicesModal`, `WriteNoteModal`), de moderação (`FlagModal`, `FlagUserModal`,
-  `UnflagModal`, `ReportDetailModal`, `ReportDetailsModal`), de conteúdo (`EventDetailsModal`,
+  `LogoutAllDevicesModal`, `WriteNoteModal`), moderation (`FlagModal`, `FlagUserModal`,
+  `UnflagModal`, `ReportDetailModal`, `ReportDetailsModal`), content (`EventDetailsModal`,
   `SpaceDetailsModal`, `IdeaDetailsModal`, `ScheduledEventsModal`, `ChangeCategoryModal`,
-  `SeeAllInterestsModal`), de admin/roles (`CreateMemberModal`, `RemoveMemberModal`,
+  `SeeAllInterestsModal`), admin/roles (`CreateMemberModal`, `RemoveMemberModal`,
   `ChangeRoleModal`, `RolePermissionsModal`, `AddAmbassadorModal`, `DeleteAmbassadorModal`),
-  genéricos (`DeleteModal`, `UnsavedChangesModal`, `DeactivatedUserModal`).
+  generic (`DeleteModal`, `UnsavedChangesModal`, `DeactivatedUserModal`).
 - **Assets/toast:** `AssetIcon`, `AssetImage`, `CustomToast`, `utils`.
 
-## 11. `pages-v2/` — as telas
+## 11. `pages-v2/` — the screens
 
-`src/pages-v2/` — cada rota de [v2Routes](../src/routes/v2Routes.tsx) tem sua tela aqui. Subpastas
-frequentemente têm `components/` locais + barril `index.ts`.
+`src/pages-v2/` — each route in [v2Routes](../src/routes/v2Routes.tsx) has its screen here. Subfolders
+often have local `components/` + an `index.ts` barrel.
 
 ```
 pages-v2/
@@ -206,64 +206,64 @@ pages-v2/
 │   ├── Community/  StudentSafety/  StudentBehavior/
 ├── Campus/               # ActiveStudents, BannedStudents,
 │                         #   DeactivatedStudents, DisengagedStudents
-├── CampusBoundary/       # componente de geofence/limite de campus
+├── CampusBoundary/       # campus geofence/boundary component
 ├── Events/               # EventsManager, EventsInsights, CheckInAnalytics
 ├── Spaces/               # SpacesManager, SpacesInsights
 ├── Ideas/                # IdeasManager, IdeasInsights
 ├── Moderation/           # ReportSafety, ReportHistory
 ├── Admin/                # AdministratorSettings, Ambassadors,
 │                         #   Campuses, RoleManagement (+ index.ts)
-├── Playground/           # 14 visualizações experimentais (Interest* + ActiveUsers*, Three.js)
+├── Playground/           # 14 experimental visualizations (Interest* + ActiveUsers*, Three.js)
 ├── LoginV2/              # login (2FA/OTP, force-password-change) + LoginV2.css
 ├── RecoverPasswordV2/    # RecoverPasswordV2 + VerifyCodeStep + ResetPasswordStep
-└── ForcePasswordChange/  # troca forçada de senha no 1º login
+└── ForcePasswordChange/  # forced password change on first login
 ```
 
-> Nota: `Dashboard` expõe os 6 painéis via export default; `Campus`, `Events`, `Spaces`, `Ideas`,
-> `Moderation`, `Admin` usam exports nomeados de barris (desembrulhados em `v2Routes` com
+> Note: `Dashboard` exposes the 6 panels via default export; `Campus`, `Events`, `Spaces`, `Ideas`,
+> `Moderation`, `Admin` use named barrel exports (unwrapped in `v2Routes` with
 > `.then(m => ({ default: m.Name }))`).
 
-## 12. `routes/` — mapa de rotas
+## 12. `routes/` — route map
 
-`src/routes/v2Routes.tsx` — único arquivo de rotas ativo. Monta `<LayoutV2/>` com as telas
-**lazy-loaded**, cada uma envolvida por `<PermissionGuard resource="..." fallback="redirect">`.
-Também provê `CampusProvider` + `DashboardProvider` e trata redirects de paths legados
-(`/campuses → /admin/campuses`, etc.). Ver [architecture §3](./architecture.md#3-roteamento-react-router-v7--lazy).
+`src/routes/v2Routes.tsx` — the only active routes file. Mounts `<LayoutV2/>` with the
+**lazy-loaded** screens, each wrapped in `<PermissionGuard resource="..." fallback="redirect">`.
+It also provides `CampusProvider` + `DashboardProvider` and handles legacy-path redirects
+(`/campuses → /admin/campuses`, etc.). See [architecture §3](./architecture.md#3-routing-react-router-v7--lazy).
 
-## 13. `types/` — tipos hand-written
+## 13. `types/` — hand-written types
 
-`src/types/` — tipos TS **escritos à mão** que estendem/combinam os gerados: `ambassador.ts`,
-`analytics.ts`, `api.ts`, `campus.ts`, `place.ts`, `placeType.ts`, `report.ts`, `role.ts`. Os
-services (`services/*`) unem esses tipos com os de `API/data-contracts.ts`/`WalkyAPI.ts` para
-entregar às telas a forma que elas esperam.
+`src/types/` — **hand-written** TS types that extend/combine the generated ones: `ambassador.ts`,
+`analytics.ts`, `api.ts`, `campus.ts`, `place.ts`, `placeType.ts`, `report.ts`, `role.ts`. The
+services (`services/*`) merge these types with those from `API/data-contracts.ts`/`WalkyAPI.ts` to
+deliver to the screens the shape they expect.
 
-## 14. `styles-v2/` e `theme.ts`
+## 14. `styles-v2/` and `theme.ts`
 
-`src/styles-v2/` — sistema de estilo dual (CoreUI + tokens V2):
+`src/styles-v2/` — a dual style system (CoreUI + V2 tokens):
 
-| Arquivo | Conteúdo |
+| File | Contents |
 |---------|----------|
-| `design-tokens.css` / `design-tokens.ts` | Tokens (spacing, cornerRadius, colors, ...) auto-gerados do Figma — CSS vars e versão TS. |
-| `theme-variables.css` | Variáveis de tema (light/dark). |
-| `ThemeComponents.css` | Estilos de componentes temáticos. |
-| `global.css` | Estilos globais. |
+| `design-tokens.css` / `design-tokens.ts` | Tokens (spacing, cornerRadius, colors, ...) auto-generated from Figma — CSS vars and TS version. |
+| `theme-variables.css` | Theme variables (light/dark). |
+| `ThemeComponents.css` | Themed component styles. |
+| `global.css` | Global styles. |
 
-`src/theme.ts` — `getTheme(isDark)` retorna o objeto de cores consumido por
-[`ThemeProvider`](../src/contexts/ThemeProvider.tsx), que aplica `data-coreui-theme` + `data-theme` +
-CSS vars `--app-*` no `<html>`/`<body>`. Ver [architecture §7](./architecture.md#7-tema-e-design-tokens).
+`src/theme.ts` — `getTheme(isDark)` returns the color object consumed by
+[`ThemeProvider`](../src/contexts/ThemeProvider.tsx), which applies `data-coreui-theme` + `data-theme`
++ `--app-*` CSS vars on `<html>`/`<body>`. See [architecture §7](./architecture.md#7-theme-and-design-tokens).
 
 ## 15. `test/`, `scripts/`, `docs/`
 
-- `src/test/` — `setup.ts` (setup do Vitest/Testing Library) e helpers; MSW para mock de rede. Testes
-  ficam ao lado do código (`*.test.ts[x]`).
-- `scripts/` — `check-test-ids.js` (exige `data-testid`), `check-accessibility.js` (a11y),
+- `src/test/` — `setup.ts` (Vitest/Testing Library setup) and helpers; MSW for network mocking. Tests
+  live next to the code (`*.test.ts[x]`).
+- `scripts/` — `check-test-ids.js` (requires `data-testid`), `check-accessibility.js` (a11y),
   `generate-icons.cjs`, `generate-images.cjs`.
-- `docs/` — esta documentação (`overview`, `architecture`, `folder-structure`), além de `docs/admin/`
-  (referência dos controllers do backend) e `docs/TESTING.md`.
+- `docs/` — this documentation (`overview`, `architecture`, `folder-structure`), plus `docs/admin/`
+  (backend controller reference) and `docs/TESTING.md`.
 
 ---
 
 ## Cross-links
 
-- [Visão geral](./overview.md) — propósito, público, stack.
-- [Arquitetura](./architecture.md) — fluxo de dados, RBAC, decisões.
+- [Overview](./overview.md) — purpose, audience, stack.
+- [Architecture](./architecture.md) — data flow, RBAC, decisions.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,314 @@
+# Integrações — walky-admin
+
+> Painel administrativo da plataforma Walky (React 19 + CoreUI 5 + Vite 7). Este documento descreve
+> **todas as integrações externas e de contrato** que o painel usa, com paths reais, arquivos de
+> configuração e variáveis de ambiente. Reflete exatamente o código do repositório.
+
+Documentos relacionados: [deployment.md](./deployment.md) · Contexto do ecossistema: [`../AI_CONTEXT.md`](../AI_CONTEXT.md)
+
+---
+
+## Sumário
+
+- [1. Visão geral](#1-visão-geral)
+- [2. Backend REST (Axios)](#2-backend-rest-axios)
+  - [2.1. Base URL e criação do cliente](#21-base-url-e-criação-do-cliente)
+  - [2.2. Bearer token](#22-bearer-token)
+  - [2.3. Proteção CSRF](#23-proteção-csrf)
+  - [2.4. Interceptors de request/response](#24-interceptors-de-requestresponse)
+  - [2.5. Camada de services + React Query](#25-camada-de-services--react-query)
+- [3. Swagger TypeScript API (geração de tipos)](#3-swagger-typescript-api-geração-de-tipos)
+- [4. Google Maps](#4-google-maps)
+- [5. Sentry](#5-sentry)
+- [6. Outras bibliotecas de dados/visualização](#6-outras-bibliotecas-de-dadosvisualização)
+- [7. Resumo de variáveis de ambiente](#7-resumo-de-variáveis-de-ambiente)
+
+---
+
+## 1. Visão geral
+
+O walky-admin é **cliente do walky-backend** (API REST). Não há WebSocket/tempo real no painel.
+As integrações efetivamente presentes no código são:
+
+| Integração | Propósito | Arquivo(s) de config | Env vars |
+|---|---|---|---|
+| **Backend REST (Axios)** | Toda a comunicação HTTP com a API | `src/API/index.ts`, `src/API/http-client.ts` | `VITE_API_BASE_URL` |
+| **Swagger TypeScript API** | Geração dos tipos/clients a partir do OpenAPI do backend | `package.json` (script `generate:api`), saída em `src/API/` | — (lê `../walky-backend/swagger.json`) |
+| **Google Maps** | Desenho de geofence/boundary do campus | `src/pages-v2/CampusBoundary/CampusBoundary.tsx` (`@react-google-maps/api`) | ⚠️ chave **hardcoded**, sem env var |
+| **React Query** | Cache de server state sobre o Axios | `src/lib/queryClient.ts` | — |
+
+> **Sentry:** o `.env.example` sugere `VITE_SENTRY_DSN`, mas **não há integração de Sentry no código**
+> (nenhum pacote, import ou init). Ver [seção 5](#5-sentry).
+
+```mermaid
+flowchart LR
+  subgraph admin["walky-admin (browser)"]
+    RQ["React Query<br/>src/lib/queryClient.ts"]
+    SVC["services/*<br/>userService, campusService…"]
+    AX["Axios client + interceptors<br/>src/API/index.ts"]
+    GEN["Cliente gerado (Swagger)<br/>src/API/WalkyAPI.ts, Api.ts…"]
+    GM["Google Maps<br/>CampusBoundary.tsx"]
+  end
+  BE["walky-backend<br/>REST /api"]
+  SW["../walky-backend/swagger.json"]
+  GAPI["Google Maps JS API"]
+
+  RQ --> SVC --> AX
+  AX -.usa tipos.-> GEN
+  AX -->|Bearer + CSRF| BE
+  SW -->|generate:api| GEN
+  GM --> GAPI
+```
+
+---
+
+## 2. Backend REST (Axios)
+
+Arquivos: [`src/API/index.ts`](../src/API/index.ts) e [`src/API/http-client.ts`](../src/API/http-client.ts) (gerado).
+
+Há **duas instâncias Axios** em `src/API/index.ts`:
+
+1. `API` (export default) — instância "manual" `axios.create(...)`, usada por código legado.
+2. `apiClient` — instância do **cliente gerado** (`new Api(new HttpClient(...))`), exportada também
+   como `httpClient` para compatibilidade. É a usada pela camada de `services/`.
+
+Ambas recebem **os mesmos interceptors** (Bearer + CSRF + tratamento de erro), definidos duas vezes
+no mesmo arquivo.
+
+### 2.1. Base URL e criação do cliente
+
+A base vem de `import.meta.env.VITE_API_BASE_URL`, com fallback `http://localhost:8080/api`:
+
+```ts
+// src/API/index.ts
+const API = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080/api",
+  withCredentials: true, // habilita cookies para CSRF
+});
+```
+
+Para o **cliente gerado**, o sufixo `/api` é **removido** da base:
+
+```ts
+// src/API/index.ts
+const baseURL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080/api";
+const httpClientInstance = new HttpClient({
+  baseURL: baseURL.replace(/\/api\/?$/, ""),
+});
+export const apiClient = new Api(httpClientInstance);
+```
+
+Motivo (comentado no código): os paths do Swagger são mistos — rotas de admin já incluem o prefixo
+`/api/admin/...`, enquanto rotas legadas (`/ambassadors`, etc.) batem no router legado na raiz. Por
+isso a base do cliente gerado é a **raiz** (sem `/api`).
+
+O `HttpClient` gerado tem fallback próprio `http://localhost:8081` caso nenhuma base seja passada
+(ver `src/API/http-client.ts`), mas na prática a base sempre é injetada por `index.ts`.
+
+Ambientes típicos de `VITE_API_BASE_URL` (ver [`.env.example`](../.env.example)):
+
+| Ambiente | Valor |
+|---|---|
+| Produção | `https://api.walkyapp.com/api` |
+| Staging | `https://staging.walkyapp.com/api` |
+| Local | `http://localhost:8081/api` (ou `8080`) |
+
+### 2.2. Bearer token
+
+O token JWT é lido de `localStorage` (chave `token`) no interceptor de request e injetado no header
+`Authorization`:
+
+```ts
+// src/API/index.ts (nas duas instâncias)
+const token = localStorage.getItem("token");
+if (token) {
+  config.headers.Authorization = `Bearer ${token}`;
+} else {
+  logger.warn("⚠️ No token found for request:", config.url);
+}
+```
+
+### 2.3. Proteção CSRF
+
+Ambas as instâncias usam `withCredentials: true` (cookies enviados). Em requests **não-GET**
+(exclui `get`/`head`/`options`), o token CSRF é lido de cookie e enviado em dois headers:
+
+```ts
+// src/API/index.ts — getCsrfToken()
+const cookieNames = ["csrf_cookie_rr", "XSRF-TOKEN", "csrf_token", "_csrf"];
+// ...
+config.headers["X-CSRF-Token"] = csrfToken;
+config.headers["X-XSRF-Token"] = csrfToken;
+```
+
+O helper `getCsrfToken()` tenta múltiplos nomes de cookie comuns e faz `decodeURIComponent`.
+
+### 2.4. Interceptors de request/response
+
+Response interceptor (idêntico nas duas instâncias):
+
+- **Log** de sucesso (`logger.debug`) e de erro (`logger.error`) com método/URL/status.
+- **401 Unauthorized:** remove `token` do `localStorage` e redireciona para `/login` (se ainda não
+  estiver lá) via `window.location.href`.
+- **403 Forbidden:** se o corpo do erro tiver `code === "ACCOUNT_DEACTIVATED"` ou
+  `"USER_DEACTIVATED"`, dispara o modal via `triggerDeactivatedModal()`
+  (`src/contexts/DeactivatedUserContext`). Erros 403 de permissão comum **não** disparam o modal.
+
+> Observação: a lógica de **retry** e a política de não-retry em 4xx (exceto 408) **não** está no
+> Axios, e sim no React Query — ver [2.5](#25-camada-de-services--react-query).
+
+### 2.5. Camada de services + React Query
+
+Os services em [`src/services/`](../src/services/) encapsulam chamadas do `apiClient` e expõem
+funções tipadas. Existentes:
+
+`ambassadorService.ts`, `analyticsService.ts`, `campusService.ts`, `campusSyncService.ts`,
+`interestService.ts`, `lockedUsersService.ts`, `placeService.ts`, `placeTypeService.ts`,
+`reportService.ts`, `rolesService.ts`, `schoolService.ts`, `userService.ts`.
+
+Cada service importa `apiClient` de `../API`, o `logger` de `../lib/logger` e tipos de
+`../API/WalkyAPI` (ex.: `src/services/userService.ts`).
+
+O **React Query** ([`src/lib/queryClient.ts`](../src/lib/queryClient.ts)) define os defaults:
+
+```ts
+queries: {
+  staleTime: 1000 * 60 * 5,  // 5 min
+  gcTime:    1000 * 60 * 10,  // 10 min
+  retry: (failureCount, error) => {
+    // não faz retry em 4xx, exceto 408 (timeout); demais até 3 tentativas
+    // ...
+    return failureCount < 3;
+  },
+  refetchOnWindowFocus: false,
+},
+mutations: { retry: 1 },
+```
+
+Há também uma `queryKeys` factory (campuses, campus, students, geofences, ambassadors…).
+
+---
+
+## 3. Swagger TypeScript API (geração de tipos)
+
+**Propósito:** gerar o cliente TypeScript + tipos de dados a partir do contrato OpenAPI do backend,
+mantendo os tipos do painel em sincronia com a API.
+
+**Comando** (em [`package.json`](../package.json)):
+
+```jsonc
+"generate:api": "npx swagger-typescript-api generate -p ../walky-backend/swagger.json -o ./src/API --axios --name WalkyAPI.ts"
+```
+
+- Ferramenta: [`swagger-typescript-api`](https://github.com/acacode/swagger-typescript-api) (autor
+  acacode) — invocada via `npx` (não é dependência declarada).
+- Entrada (`-p`): **`../walky-backend/swagger.json`** — o repositório `walky-backend` precisa estar
+  clonado ao lado, e o `swagger.json` gerado/exportado. Não há download remoto do spec.
+- Saída (`-o`): **`./src/API`**.
+- Flags: `--axios` (cliente baseado em Axios) e `--name WalkyAPI.ts` (nome do arquivo principal).
+
+**Arquivos gerados em [`src/API/`](../src/API/):** todos começam com o cabeçalho
+`## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API` — **não editar à mão**:
+
+- `WalkyAPI.ts` — arquivo principal (nome via `--name`); exporta `Api` e `HttpClient` (~378 KB).
+- `Api.ts` — variante do cliente completo (~374 KB).
+- `http-client.ts` — classe `HttpClient` (wrapper Axios genérico: `mergeRequestParams`,
+  `createFormData`, `request`, etc.).
+- `data-contracts.ts` — interfaces de tipos de dados.
+- Clients por domínio: `Admin.ts`, `Age.ts`, `Ambassadors.ts`, `Analytics.ts`, `Audit.ts`,
+  `Auth.ts`, `Users.ts`.
+
+> `src/API/index.ts` **não** é gerado — é o wrapper manual que configura base, interceptors e
+> exporta `apiClient`/`httpClient`/`API`.
+
+**Fluxo de contrato (comum a app/admin/hq):** mudança no backend → regenerar `swagger.json` no
+backend → rodar `generate:api` no admin → recompilar. Ver [`../AI_CONTEXT.md`](../AI_CONTEXT.md) §0.
+
+```mermaid
+flowchart LR
+  BE["walky-backend"] -->|exporta| SW["swagger.json"]
+  SW -->|generate:api<br/>swagger-typescript-api| OUT["src/API/*.ts<br/>(WalkyAPI, Api, http-client,<br/>data-contracts, Admin…)"]
+  OUT -->|Api + HttpClient| IDX["src/API/index.ts<br/>(wrapper: base + interceptors)"]
+  IDX -->|apiClient| SVC["src/services/*"]
+```
+
+---
+
+## 4. Google Maps
+
+**Propósito:** desenhar e editar o **boundary/geofence do campus** (polígono GeoJSON) na tela de
+configuração de campus.
+
+**Arquivo:** [`src/pages-v2/CampusBoundary/CampusBoundary.tsx`](../src/pages-v2/CampusBoundary/CampusBoundary.tsx)
+
+**Biblioteca:** [`@react-google-maps/api`](https://www.npmjs.com/package/@react-google-maps/api)
+(`^2.20.7`) — usa `useJsApiLoader`, `GoogleMap`, `StandaloneSearchBox`, `Libraries`.
+
+```ts
+// src/pages-v2/CampusBoundary/CampusBoundary.tsx
+const libraries: Libraries = ["places"]; // DrawingManager foi removido na Maps JS v3.65
+const { isLoaded, loadError } = useJsApiLoader({
+  id: "google-map-script",
+  googleMapsApiKey: "AIzaSyAumxyJ5Z1j-_X1EHUSy8GCRr21zDPzSHs",
+  libraries,
+});
+```
+
+> ⚠️ **Atenção — chave hardcoded:** a `googleMapsApiKey` está **fixa no código-fonte**, não vem de
+> variável de ambiente. Apesar de o `.env.example` sugerir `VITE_GOOGLE_MAPS_API_KEY`, essa env var
+> **não é lida em nenhum lugar** de `src/`. O único uso de env var no código é `VITE_API_BASE_URL`
+> (e `import.meta.env.DEV`). Recomenda-se migrar a chave para `VITE_GOOGLE_MAPS_API_KEY` e restringi-la.
+
+O polígono é desenhado manualmente com listeners de clique do mapa (a `drawing library` não é mais
+usada porque `DrawingManager` foi removido na Maps JS API v3.65). Os tipos vêm de
+`@types/google.maps` (`^3.58.1`).
+
+---
+
+## 5. Sentry
+
+**Não há integração de Sentry no código.** Não existe pacote `@sentry/*` no
+[`package.json`](../package.json), nem `import`/`init` de Sentry em `src/`.
+
+O [`.env.example`](../.env.example) menciona `VITE_SENTRY_DSN` apenas como comentário ("Other
+potential environment variables"), mas essa variável **não é consumida** em lugar nenhum. Tratar como
+placeholder/intenção futura, não como integração ativa.
+
+O que existe no lugar é um **logger próprio** ([`src/lib/logger.ts`](../src/lib/logger.ts)):
+`debug`/`info` só em dev (`import.meta.env.DEV`), `warn`/`error` sempre — para não vazar PII no
+console em produção. É o logger usado pelos interceptors do Axios e pelos services.
+
+---
+
+## 6. Outras bibliotecas de dados/visualização
+
+Não são "integrações externas" (não chamam serviços de terceiros), mas fazem parte da camada de
+dados/visualização do painel:
+
+- **Recharts** (`^3.4.1`) — gráficos dos dashboards. Uso em
+  `src/pages-v2/Dashboard/components/LineChart/LineChart.tsx` e
+  `src/pages-v2/Dashboard/components/DonutChart/DonutChart.tsx` (e mock em `src/test/setup.ts`).
+- **Three.js** + `@react-three/fiber` + `@react-three/drei` — visualizações 3D experimentais do
+  **Playground** (`src/pages-v2/Playground/*` — ex.: `InterestCloud`, `InterestConstellation`,
+  `ActiveUsersSpiral`, `ActiveUsersOrbs`…). Todas as ~13 telas 3D usam Three.js; o Playground **não**
+  usa Recharts.
+- **html2canvas** / **html2pdf.js** — export de relatórios (PDF/imagem).
+- **date-fns**, **react-hot-toast**, **simplebar-react**, **lucide-react** — utilidades de UI.
+
+---
+
+## 7. Resumo de variáveis de ambiente
+
+Ver detalhes de config/deploy em [deployment.md](./deployment.md#variáveis-de-ambiente).
+
+| Variável | Onde é lida | Obrigatória | Observação |
+|---|---|---|---|
+| `VITE_API_BASE_URL` | `src/API/index.ts`, `src/test/handlers.ts` | Efetivamente sim | Fallback `http://localhost:8080/api`. Cliente gerado remove o sufixo `/api`. |
+| `VITE_APP_NAME` | `.env.example` | Não (não lida em `src/`) | Ex.: `Walky Admin`. |
+| `VITE_ENV` | `.env.example` | Não (não lida em `src/`) | `development` / `staging` / `production`. |
+| `VITE_GOOGLE_MAPS_API_KEY` | — | Não | Sugerida no `.env.example`, mas **não usada** — a chave está hardcoded em `CampusBoundary.tsx`. |
+| `VITE_SENTRY_DSN` | — | Não | Sugerida no `.env.example`, mas **sem integração** de Sentry. |
+| `import.meta.env.DEV` | `src/lib/logger.ts` | (built-in Vite) | Ativa logs de dev. |
+
+> Único uso real de env var de aplicação em `src/` = **`VITE_API_BASE_URL`**. As demais são apenas
+> sugestões do `.env.example`.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,44 +1,44 @@
-# Integrações — walky-admin
+# Integrations — walky-admin
 
-> Painel administrativo da plataforma Walky (React 19 + CoreUI 5 + Vite 7). Este documento descreve
-> **todas as integrações externas e de contrato** que o painel usa, com paths reais, arquivos de
-> configuração e variáveis de ambiente. Reflete exatamente o código do repositório.
+> Administrative dashboard for the Walky platform (React 19 + CoreUI 5 + Vite 7). This document
+> describes **all external and contract integrations** the dashboard uses, with real paths,
+> configuration files, and environment variables. It reflects the repository code exactly.
 
-Documentos relacionados: [deployment.md](./deployment.md) · Contexto do ecossistema: [`../AI_CONTEXT.md`](../AI_CONTEXT.md)
+Related documents: [deployment.md](./deployment.md) · Ecosystem context: [`../AI_CONTEXT.md`](../AI_CONTEXT.md)
 
 ---
 
-## Sumário
+## Table of Contents
 
-- [1. Visão geral](#1-visão-geral)
+- [1. Overview](#1-overview)
 - [2. Backend REST (Axios)](#2-backend-rest-axios)
-  - [2.1. Base URL e criação do cliente](#21-base-url-e-criação-do-cliente)
+  - [2.1. Base URL and client creation](#21-base-url-and-client-creation)
   - [2.2. Bearer token](#22-bearer-token)
-  - [2.3. Proteção CSRF](#23-proteção-csrf)
-  - [2.4. Interceptors de request/response](#24-interceptors-de-requestresponse)
-  - [2.5. Camada de services + React Query](#25-camada-de-services--react-query)
-- [3. Swagger TypeScript API (geração de tipos)](#3-swagger-typescript-api-geração-de-tipos)
+  - [2.3. CSRF protection](#23-csrf-protection)
+  - [2.4. Request/response interceptors](#24-requestresponse-interceptors)
+  - [2.5. Services layer + React Query](#25-services-layer--react-query)
+- [3. Swagger TypeScript API (type generation)](#3-swagger-typescript-api-type-generation)
 - [4. Google Maps](#4-google-maps)
 - [5. Sentry](#5-sentry)
-- [6. Outras bibliotecas de dados/visualização](#6-outras-bibliotecas-de-dadosvisualização)
-- [7. Resumo de variáveis de ambiente](#7-resumo-de-variáveis-de-ambiente)
+- [6. Other data/visualization libraries](#6-other-datavisualization-libraries)
+- [7. Environment variables summary](#7-environment-variables-summary)
 
 ---
 
-## 1. Visão geral
+## 1. Overview
 
-O walky-admin é **cliente do walky-backend** (API REST). Não há WebSocket/tempo real no painel.
-As integrações efetivamente presentes no código são:
+walky-admin is a **client of walky-backend** (REST API). There is no WebSocket/real-time in the
+dashboard. The integrations actually present in the code are:
 
-| Integração | Propósito | Arquivo(s) de config | Env vars |
+| Integration | Purpose | Config file(s) | Env vars |
 |---|---|---|---|
-| **Backend REST (Axios)** | Toda a comunicação HTTP com a API | `src/API/index.ts`, `src/API/http-client.ts` | `VITE_API_BASE_URL` |
-| **Swagger TypeScript API** | Geração dos tipos/clients a partir do OpenAPI do backend | `package.json` (script `generate:api`), saída em `src/API/` | — (lê `../walky-backend/swagger.json`) |
-| **Google Maps** | Desenho de geofence/boundary do campus | `src/pages-v2/CampusBoundary/CampusBoundary.tsx` (`@react-google-maps/api`) | ⚠️ chave **hardcoded**, sem env var |
-| **React Query** | Cache de server state sobre o Axios | `src/lib/queryClient.ts` | — |
+| **Backend REST (Axios)** | All HTTP communication with the API | `src/API/index.ts`, `src/API/http-client.ts` | `VITE_API_BASE_URL` |
+| **Swagger TypeScript API** | Generates types/clients from the backend OpenAPI | `package.json` (`generate:api` script), output in `src/API/` | — (reads `../walky-backend/swagger.json`) |
+| **Google Maps** | Drawing the campus geofence/boundary | `src/pages-v2/CampusBoundary/CampusBoundary.tsx` (`@react-google-maps/api`) | ⚠️ key is **hardcoded**, no env var |
+| **React Query** | Server-state cache over Axios | `src/lib/queryClient.ts` | — |
 
-> **Sentry:** o `.env.example` sugere `VITE_SENTRY_DSN`, mas **não há integração de Sentry no código**
-> (nenhum pacote, import ou init). Ver [seção 5](#5-sentry).
+> **Sentry:** `.env.example` suggests `VITE_SENTRY_DSN`, but **there is no Sentry integration in the
+> code** (no package, import, or init). See [section 5](#5-sentry).
 
 ```mermaid
 flowchart LR
@@ -46,7 +46,7 @@ flowchart LR
     RQ["React Query<br/>src/lib/queryClient.ts"]
     SVC["services/*<br/>userService, campusService…"]
     AX["Axios client + interceptors<br/>src/API/index.ts"]
-    GEN["Cliente gerado (Swagger)<br/>src/API/WalkyAPI.ts, Api.ts…"]
+    GEN["Generated client (Swagger)<br/>src/API/WalkyAPI.ts, Api.ts…"]
     GM["Google Maps<br/>CampusBoundary.tsx"]
   end
   BE["walky-backend<br/>REST /api"]
@@ -54,7 +54,7 @@ flowchart LR
   GAPI["Google Maps JS API"]
 
   RQ --> SVC --> AX
-  AX -.usa tipos.-> GEN
+  AX -.uses types.-> GEN
   AX -->|Bearer + CSRF| BE
   SW -->|generate:api| GEN
   GM --> GAPI
@@ -64,20 +64,20 @@ flowchart LR
 
 ## 2. Backend REST (Axios)
 
-Arquivos: [`src/API/index.ts`](../src/API/index.ts) e [`src/API/http-client.ts`](../src/API/http-client.ts) (gerado).
+Files: [`src/API/index.ts`](../src/API/index.ts) and [`src/API/http-client.ts`](../src/API/http-client.ts) (generated).
 
-Há **duas instâncias Axios** em `src/API/index.ts`:
+There are **two Axios instances** in `src/API/index.ts`:
 
-1. `API` (export default) — instância "manual" `axios.create(...)`, usada por código legado.
-2. `apiClient` — instância do **cliente gerado** (`new Api(new HttpClient(...))`), exportada também
-   como `httpClient` para compatibilidade. É a usada pela camada de `services/`.
+1. `API` (default export) — the "manual" `axios.create(...)` instance, used by legacy code.
+2. `apiClient` — the **generated client** instance (`new Api(new HttpClient(...))`), also exported
+   as `httpClient` for compatibility. This is the one used by the `services/` layer.
 
-Ambas recebem **os mesmos interceptors** (Bearer + CSRF + tratamento de erro), definidos duas vezes
-no mesmo arquivo.
+Both receive **the same interceptors** (Bearer + CSRF + error handling), defined twice in the same
+file.
 
-### 2.1. Base URL e criação do cliente
+### 2.1. Base URL and client creation
 
-A base vem de `import.meta.env.VITE_API_BASE_URL`, com fallback `http://localhost:8080/api`:
+The base comes from `import.meta.env.VITE_API_BASE_URL`, with a `http://localhost:8080/api` fallback:
 
 ```ts
 // src/API/index.ts
@@ -87,7 +87,7 @@ const API = axios.create({
 });
 ```
 
-Para o **cliente gerado**, o sufixo `/api` é **removido** da base:
+For the **generated client**, the `/api` suffix is **removed** from the base:
 
 ```ts
 // src/API/index.ts
@@ -98,28 +98,28 @@ const httpClientInstance = new HttpClient({
 export const apiClient = new Api(httpClientInstance);
 ```
 
-Motivo (comentado no código): os paths do Swagger são mistos — rotas de admin já incluem o prefixo
-`/api/admin/...`, enquanto rotas legadas (`/ambassadors`, etc.) batem no router legado na raiz. Por
-isso a base do cliente gerado é a **raiz** (sem `/api`).
+Reason (noted in the code): the Swagger paths are mixed — admin routes already include the
+`/api/admin/...` prefix, while legacy routes (`/ambassadors`, etc.) hit the legacy router at the
+root. That's why the generated client's base is the **root** (without `/api`).
 
-O `HttpClient` gerado tem fallback próprio `http://localhost:8081` caso nenhuma base seja passada
-(ver `src/API/http-client.ts`), mas na prática a base sempre é injetada por `index.ts`.
+The generated `HttpClient` has its own `http://localhost:8081` fallback if no base is passed (see
+`src/API/http-client.ts`), but in practice the base is always injected by `index.ts`.
 
-Ambientes típicos de `VITE_API_BASE_URL` (ver [`.env.example`](../.env.example)):
+Typical `VITE_API_BASE_URL` environments (see [`.env.example`](../.env.example)):
 
-| Ambiente | Valor |
+| Environment | Value |
 |---|---|
-| Produção | `https://api.walkyapp.com/api` |
+| Production | `https://api.walkyapp.com/api` |
 | Staging | `https://staging.walkyapp.com/api` |
-| Local | `http://localhost:8081/api` (ou `8080`) |
+| Local | `http://localhost:8081/api` (or `8080`) |
 
 ### 2.2. Bearer token
 
-O token JWT é lido de `localStorage` (chave `token`) no interceptor de request e injetado no header
-`Authorization`:
+The JWT token is read from `localStorage` (key `token`) in the request interceptor and injected into
+the `Authorization` header:
 
 ```ts
-// src/API/index.ts (nas duas instâncias)
+// src/API/index.ts (in both instances)
 const token = localStorage.getItem("token");
 if (token) {
   config.headers.Authorization = `Bearer ${token}`;
@@ -128,10 +128,10 @@ if (token) {
 }
 ```
 
-### 2.3. Proteção CSRF
+### 2.3. CSRF protection
 
-Ambas as instâncias usam `withCredentials: true` (cookies enviados). Em requests **não-GET**
-(exclui `get`/`head`/`options`), o token CSRF é lido de cookie e enviado em dois headers:
+Both instances use `withCredentials: true` (cookies are sent). On **non-GET** requests (excluding
+`get`/`head`/`options`), the CSRF token is read from a cookie and sent in two headers:
 
 ```ts
 // src/API/index.ts — getCsrfToken()
@@ -141,42 +141,42 @@ config.headers["X-CSRF-Token"] = csrfToken;
 config.headers["X-XSRF-Token"] = csrfToken;
 ```
 
-O helper `getCsrfToken()` tenta múltiplos nomes de cookie comuns e faz `decodeURIComponent`.
+The `getCsrfToken()` helper tries several common cookie names and runs `decodeURIComponent`.
 
-### 2.4. Interceptors de request/response
+### 2.4. Request/response interceptors
 
-Response interceptor (idêntico nas duas instâncias):
+Response interceptor (identical in both instances):
 
-- **Log** de sucesso (`logger.debug`) e de erro (`logger.error`) com método/URL/status.
-- **401 Unauthorized:** remove `token` do `localStorage` e redireciona para `/login` (se ainda não
-  estiver lá) via `window.location.href`.
-- **403 Forbidden:** se o corpo do erro tiver `code === "ACCOUNT_DEACTIVATED"` ou
-  `"USER_DEACTIVATED"`, dispara o modal via `triggerDeactivatedModal()`
-  (`src/contexts/DeactivatedUserContext`). Erros 403 de permissão comum **não** disparam o modal.
+- **Logs** on success (`logger.debug`) and error (`logger.error`) with method/URL/status.
+- **401 Unauthorized:** removes `token` from `localStorage` and redirects to `/login` (if not
+  already there) via `window.location.href`.
+- **403 Forbidden:** if the error body has `code === "ACCOUNT_DEACTIVATED"` or
+  `"USER_DEACTIVATED"`, it opens the modal via `triggerDeactivatedModal()`
+  (`src/contexts/DeactivatedUserContext`). Ordinary permission 403 errors do **not** open the modal.
 
-> Observação: a lógica de **retry** e a política de não-retry em 4xx (exceto 408) **não** está no
-> Axios, e sim no React Query — ver [2.5](#25-camada-de-services--react-query).
+> Note: the **retry** logic and the no-retry policy on 4xx (except 408) are **not** in Axios but in
+> React Query — see [2.5](#25-services-layer--react-query).
 
-### 2.5. Camada de services + React Query
+### 2.5. Services layer + React Query
 
-Os services em [`src/services/`](../src/services/) encapsulam chamadas do `apiClient` e expõem
-funções tipadas. Existentes:
+The services in [`src/services/`](../src/services/) wrap `apiClient` calls and expose typed
+functions. Existing ones:
 
 `ambassadorService.ts`, `analyticsService.ts`, `campusService.ts`, `campusSyncService.ts`,
 `interestService.ts`, `lockedUsersService.ts`, `placeService.ts`, `placeTypeService.ts`,
 `reportService.ts`, `rolesService.ts`, `schoolService.ts`, `userService.ts`.
 
-Cada service importa `apiClient` de `../API`, o `logger` de `../lib/logger` e tipos de
-`../API/WalkyAPI` (ex.: `src/services/userService.ts`).
+Each service imports `apiClient` from `../API`, `logger` from `../lib/logger`, and types from
+`../API/WalkyAPI` (e.g., `src/services/userService.ts`).
 
-O **React Query** ([`src/lib/queryClient.ts`](../src/lib/queryClient.ts)) define os defaults:
+**React Query** ([`src/lib/queryClient.ts`](../src/lib/queryClient.ts)) sets the defaults:
 
 ```ts
 queries: {
   staleTime: 1000 * 60 * 5,  // 5 min
   gcTime:    1000 * 60 * 10,  // 10 min
   retry: (failureCount, error) => {
-    // não faz retry em 4xx, exceto 408 (timeout); demais até 3 tentativas
+    // no retry on 4xx, except 408 (timeout); otherwise up to 3 attempts
     // ...
     return failureCount < 3;
   },
@@ -185,48 +185,48 @@ queries: {
 mutations: { retry: 1 },
 ```
 
-Há também uma `queryKeys` factory (campuses, campus, students, geofences, ambassadors…).
+There is also a `queryKeys` factory (campuses, campus, students, geofences, ambassadors…).
 
 ---
 
-## 3. Swagger TypeScript API (geração de tipos)
+## 3. Swagger TypeScript API (type generation)
 
-**Propósito:** gerar o cliente TypeScript + tipos de dados a partir do contrato OpenAPI do backend,
-mantendo os tipos do painel em sincronia com a API.
+**Purpose:** generate the TypeScript client + data types from the backend's OpenAPI contract,
+keeping the dashboard's types in sync with the API.
 
-**Comando** (em [`package.json`](../package.json)):
+**Command** (in [`package.json`](../package.json)):
 
 ```jsonc
 "generate:api": "npx swagger-typescript-api generate -p ../walky-backend/swagger.json -o ./src/API --axios --name WalkyAPI.ts"
 ```
 
-- Ferramenta: [`swagger-typescript-api`](https://github.com/acacode/swagger-typescript-api) (autor
-  acacode) — invocada via `npx` (não é dependência declarada).
-- Entrada (`-p`): **`../walky-backend/swagger.json`** — o repositório `walky-backend` precisa estar
-  clonado ao lado, e o `swagger.json` gerado/exportado. Não há download remoto do spec.
-- Saída (`-o`): **`./src/API`**.
-- Flags: `--axios` (cliente baseado em Axios) e `--name WalkyAPI.ts` (nome do arquivo principal).
+- Tool: [`swagger-typescript-api`](https://github.com/acacode/swagger-typescript-api) (author
+  acacode) — invoked via `npx` (not a declared dependency).
+- Input (`-p`): **`../walky-backend/swagger.json`** — the `walky-backend` repository must be cloned
+  alongside, with `swagger.json` generated/exported. There is no remote download of the spec.
+- Output (`-o`): **`./src/API`**.
+- Flags: `--axios` (Axios-based client) and `--name WalkyAPI.ts` (main file name).
 
-**Arquivos gerados em [`src/API/`](../src/API/):** todos começam com o cabeçalho
-`## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API` — **não editar à mão**:
+**Files generated in [`src/API/`](../src/API/):** all begin with the header
+`## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API` — **do not edit by hand**:
 
-- `WalkyAPI.ts` — arquivo principal (nome via `--name`); exporta `Api` e `HttpClient` (~378 KB).
-- `Api.ts` — variante do cliente completo (~374 KB).
-- `http-client.ts` — classe `HttpClient` (wrapper Axios genérico: `mergeRequestParams`,
+- `WalkyAPI.ts` — main file (name via `--name`); exports `Api` and `HttpClient` (~378 KB).
+- `Api.ts` — variant of the full client (~374 KB).
+- `http-client.ts` — the `HttpClient` class (generic Axios wrapper: `mergeRequestParams`,
   `createFormData`, `request`, etc.).
-- `data-contracts.ts` — interfaces de tipos de dados.
-- Clients por domínio: `Admin.ts`, `Age.ts`, `Ambassadors.ts`, `Analytics.ts`, `Audit.ts`,
+- `data-contracts.ts` — data type interfaces.
+- Per-domain clients: `Admin.ts`, `Age.ts`, `Ambassadors.ts`, `Analytics.ts`, `Audit.ts`,
   `Auth.ts`, `Users.ts`.
 
-> `src/API/index.ts` **não** é gerado — é o wrapper manual que configura base, interceptors e
-> exporta `apiClient`/`httpClient`/`API`.
+> `src/API/index.ts` is **not** generated — it's the manual wrapper that configures the base,
+> interceptors, and exports `apiClient`/`httpClient`/`API`.
 
-**Fluxo de contrato (comum a app/admin/hq):** mudança no backend → regenerar `swagger.json` no
-backend → rodar `generate:api` no admin → recompilar. Ver [`../AI_CONTEXT.md`](../AI_CONTEXT.md) §0.
+**Contract flow (common to app/admin/hq):** backend change → regenerate `swagger.json` in the
+backend → run `generate:api` in admin → rebuild. See [`../AI_CONTEXT.md`](../AI_CONTEXT.md) §0.
 
 ```mermaid
 flowchart LR
-  BE["walky-backend"] -->|exporta| SW["swagger.json"]
+  BE["walky-backend"] -->|exports| SW["swagger.json"]
   SW -->|generate:api<br/>swagger-typescript-api| OUT["src/API/*.ts<br/>(WalkyAPI, Api, http-client,<br/>data-contracts, Admin…)"]
   OUT -->|Api + HttpClient| IDX["src/API/index.ts<br/>(wrapper: base + interceptors)"]
   IDX -->|apiClient| SVC["src/services/*"]
@@ -236,13 +236,13 @@ flowchart LR
 
 ## 4. Google Maps
 
-**Propósito:** desenhar e editar o **boundary/geofence do campus** (polígono GeoJSON) na tela de
-configuração de campus.
+**Purpose:** draw and edit the **campus boundary/geofence** (GeoJSON polygon) on the campus
+configuration screen.
 
-**Arquivo:** [`src/pages-v2/CampusBoundary/CampusBoundary.tsx`](../src/pages-v2/CampusBoundary/CampusBoundary.tsx)
+**File:** [`src/pages-v2/CampusBoundary/CampusBoundary.tsx`](../src/pages-v2/CampusBoundary/CampusBoundary.tsx)
 
-**Biblioteca:** [`@react-google-maps/api`](https://www.npmjs.com/package/@react-google-maps/api)
-(`^2.20.7`) — usa `useJsApiLoader`, `GoogleMap`, `StandaloneSearchBox`, `Libraries`.
+**Library:** [`@react-google-maps/api`](https://www.npmjs.com/package/@react-google-maps/api)
+(`^2.20.7`) — uses `useJsApiLoader`, `GoogleMap`, `StandaloneSearchBox`, `Libraries`.
 
 ```ts
 // src/pages-v2/CampusBoundary/CampusBoundary.tsx
@@ -254,61 +254,62 @@ const { isLoaded, loadError } = useJsApiLoader({
 });
 ```
 
-> ⚠️ **Atenção — chave hardcoded:** a `googleMapsApiKey` está **fixa no código-fonte**, não vem de
-> variável de ambiente. Apesar de o `.env.example` sugerir `VITE_GOOGLE_MAPS_API_KEY`, essa env var
-> **não é lida em nenhum lugar** de `src/`. O único uso de env var no código é `VITE_API_BASE_URL`
-> (e `import.meta.env.DEV`). Recomenda-se migrar a chave para `VITE_GOOGLE_MAPS_API_KEY` e restringi-la.
+> ⚠️ **Warning — hardcoded key:** the `googleMapsApiKey` is **baked into the source code**; it does
+> not come from an environment variable. Although `.env.example` suggests `VITE_GOOGLE_MAPS_API_KEY`,
+> that env var is **not read anywhere** in `src/`. The only env var used in the code is
+> `VITE_API_BASE_URL` (and `import.meta.env.DEV`). We recommend moving the key to
+> `VITE_GOOGLE_MAPS_API_KEY` and restricting it.
 
-O polígono é desenhado manualmente com listeners de clique do mapa (a `drawing library` não é mais
-usada porque `DrawingManager` foi removido na Maps JS API v3.65). Os tipos vêm de
-`@types/google.maps` (`^3.58.1`).
+The polygon is drawn manually with map click listeners (the `drawing library` is no longer used
+because `DrawingManager` was removed in Maps JS API v3.65). Types come from `@types/google.maps`
+(`^3.58.1`).
 
 ---
 
 ## 5. Sentry
 
-**Não há integração de Sentry no código.** Não existe pacote `@sentry/*` no
-[`package.json`](../package.json), nem `import`/`init` de Sentry em `src/`.
+**There is no Sentry integration in the code.** There is no `@sentry/*` package in
+[`package.json`](../package.json), nor any Sentry `import`/`init` in `src/`.
 
-O [`.env.example`](../.env.example) menciona `VITE_SENTRY_DSN` apenas como comentário ("Other
-potential environment variables"), mas essa variável **não é consumida** em lugar nenhum. Tratar como
-placeholder/intenção futura, não como integração ativa.
+[`.env.example`](../.env.example) mentions `VITE_SENTRY_DSN` only as a comment ("Other potential
+environment variables"), but that variable is **not consumed** anywhere. Treat it as a
+placeholder/future intent, not an active integration.
 
-O que existe no lugar é um **logger próprio** ([`src/lib/logger.ts`](../src/lib/logger.ts)):
-`debug`/`info` só em dev (`import.meta.env.DEV`), `warn`/`error` sempre — para não vazar PII no
-console em produção. É o logger usado pelos interceptors do Axios e pelos services.
-
----
-
-## 6. Outras bibliotecas de dados/visualização
-
-Não são "integrações externas" (não chamam serviços de terceiros), mas fazem parte da camada de
-dados/visualização do painel:
-
-- **Recharts** (`^3.4.1`) — gráficos dos dashboards. Uso em
-  `src/pages-v2/Dashboard/components/LineChart/LineChart.tsx` e
-  `src/pages-v2/Dashboard/components/DonutChart/DonutChart.tsx` (e mock em `src/test/setup.ts`).
-- **Three.js** + `@react-three/fiber` + `@react-three/drei` — visualizações 3D experimentais do
-  **Playground** (`src/pages-v2/Playground/*` — ex.: `InterestCloud`, `InterestConstellation`,
-  `ActiveUsersSpiral`, `ActiveUsersOrbs`…). Todas as ~13 telas 3D usam Three.js; o Playground **não**
-  usa Recharts.
-- **html2canvas** / **html2pdf.js** — export de relatórios (PDF/imagem).
-- **date-fns**, **react-hot-toast**, **simplebar-react**, **lucide-react** — utilidades de UI.
+What exists instead is a **custom logger** ([`src/lib/logger.ts`](../src/lib/logger.ts)):
+`debug`/`info` only in dev (`import.meta.env.DEV`), `warn`/`error` always — to avoid leaking PII in
+the console in production. It's the logger used by the Axios interceptors and the services.
 
 ---
 
-## 7. Resumo de variáveis de ambiente
+## 6. Other data/visualization libraries
 
-Ver detalhes de config/deploy em [deployment.md](./deployment.md#variáveis-de-ambiente).
+These are not "external integrations" (they don't call third-party services), but they are part of
+the dashboard's data/visualization layer:
 
-| Variável | Onde é lida | Obrigatória | Observação |
+- **Recharts** (`^3.4.1`) — dashboard charts. Used in
+  `src/pages-v2/Dashboard/components/LineChart/LineChart.tsx` and
+  `src/pages-v2/Dashboard/components/DonutChart/DonutChart.tsx` (and mocked in `src/test/setup.ts`).
+- **Three.js** + `@react-three/fiber` + `@react-three/drei` — experimental 3D visualizations in the
+  **Playground** (`src/pages-v2/Playground/*` — e.g., `InterestCloud`, `InterestConstellation`,
+  `ActiveUsersSpiral`, `ActiveUsersOrbs`…). All ~13 3D screens use Three.js; the Playground does
+  **not** use Recharts.
+- **html2canvas** / **html2pdf.js** — report export (PDF/image).
+- **date-fns**, **react-hot-toast**, **simplebar-react**, **lucide-react** — UI utilities.
+
+---
+
+## 7. Environment variables summary
+
+See config/deploy details in [deployment.md](./deployment.md#2-environment-variables).
+
+| Variable | Where it's read | Required | Note |
 |---|---|---|---|
-| `VITE_API_BASE_URL` | `src/API/index.ts`, `src/test/handlers.ts` | Efetivamente sim | Fallback `http://localhost:8080/api`. Cliente gerado remove o sufixo `/api`. |
-| `VITE_APP_NAME` | `.env.example` | Não (não lida em `src/`) | Ex.: `Walky Admin`. |
-| `VITE_ENV` | `.env.example` | Não (não lida em `src/`) | `development` / `staging` / `production`. |
-| `VITE_GOOGLE_MAPS_API_KEY` | — | Não | Sugerida no `.env.example`, mas **não usada** — a chave está hardcoded em `CampusBoundary.tsx`. |
-| `VITE_SENTRY_DSN` | — | Não | Sugerida no `.env.example`, mas **sem integração** de Sentry. |
-| `import.meta.env.DEV` | `src/lib/logger.ts` | (built-in Vite) | Ativa logs de dev. |
+| `VITE_API_BASE_URL` | `src/API/index.ts`, `src/test/handlers.ts` | Effectively yes | Fallback `http://localhost:8080/api`. The generated client strips the `/api` suffix. |
+| `VITE_APP_NAME` | `.env.example` | No (not read in `src/`) | E.g., `Walky Admin`. |
+| `VITE_ENV` | `.env.example` | No (not read in `src/`) | `development` / `staging` / `production`. |
+| `VITE_GOOGLE_MAPS_API_KEY` | — | No | Suggested in `.env.example`, but **not used** — the key is hardcoded in `CampusBoundary.tsx`. |
+| `VITE_SENTRY_DSN` | — | No | Suggested in `.env.example`, but **no Sentry integration**. |
+| `import.meta.env.DEV` | `src/lib/logger.ts` | (Vite built-in) | Enables dev logs. |
 
-> Único uso real de env var de aplicação em `src/` = **`VITE_API_BASE_URL`**. As demais são apenas
-> sugestões do `.env.example`.
+> The only real application env var used in `src/` = **`VITE_API_BASE_URL`**. The rest are just
+> suggestions from `.env.example`.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,262 +1,262 @@
-# Walky Admin — Visão Geral
+# Walky Admin — Overview
 
-> Painel administrativo da plataforma Walky. React 19 + CoreUI 5 + Vite 7. Cliente do
-> `walky-backend`, com tipos TypeScript gerados a partir do Swagger/OpenAPI do backend.
+> Administrative panel of the Walky platform. React 19 + CoreUI 5 + Vite 7. Client of
+> `walky-backend`, with TypeScript types generated from the backend's Swagger/OpenAPI.
 
-## Índice
+## Table of Contents
 
-- [1. Propósito](#1-propósito)
-- [2. O problema que resolve](#2-o-problema-que-resolve)
-- [3. Papel no ecossistema Walky](#3-papel-no-ecossistema-walky)
-- [4. Público-alvo (RBAC de roles)](#4-público-alvo-rbac-de-roles)
-- [5. Quem consome / o que gerencia](#5-quem-consome--o-que-gerencia)
-- [6. Stack completa (versões reais e o porquê)](#6-stack-completa-versões-reais-e-o-porquê)
-- [7. Variáveis de ambiente](#7-variáveis-de-ambiente)
-- [8. Scripts de build/run](#8-scripts-de-buildrun)
+- [1. Purpose](#1-purpose)
+- [2. The problem it solves](#2-the-problem-it-solves)
+- [3. Role in the Walky ecosystem](#3-role-in-the-walky-ecosystem)
+- [4. Target audience (role-based RBAC)](#4-target-audience-role-based-rbac)
+- [5. Who consumes it / what it manages](#5-who-consumes-it--what-it-manages)
+- [6. Full stack (actual versions and the rationale)](#6-full-stack-actual-versions-and-the-rationale)
+- [7. Environment variables](#7-environment-variables)
+- [8. Build/run scripts](#8-buildrun-scripts)
 - [Cross-links](#cross-links)
 
 ---
 
-## 1. Propósito
+## 1. Purpose
 
-O **walky-admin** é o **painel administrativo web** da plataforma Walky — uma rede social para
-campus universitários. Ele dá a **admins de campus, admins de escola, moderadores e super-admins**
-(além de funcionários internos com visibilidade "read-only") as ferramentas operacionais para
-gerenciar a comunidade de estudantes, o conteúdo gerado por eles e a configuração de cada campus.
+**walky-admin** is the **web administrative panel** of the Walky platform — a social network for
+university campuses. It gives **campus admins, school admins, moderators, and super-admins**
+(plus internal staff with "read-only" visibility) the operational tools to
+manage the student community, the content they generate, and the configuration of each campus.
 
-É uma **Single Page Application (SPA)** construída com **CoreUI** (biblioteca de componentes de
-admin sobre Bootstrap 5). Todo o seu estado de servidor vem do backend Walky via HTTP; ele não tem
-banco de dados próprio.
+It is a **Single Page Application (SPA)** built with **CoreUI** (an admin component
+library on top of Bootstrap 5). All of its server state comes from the backend Walky via HTTP; it has no
+database of its own.
 
-O nome do pacote em `package.json` é literalmente `admin-panel` (`version: 0.0.0`, privado).
+The package name in `package.json` is literally `admin-panel` (`version: 0.0.0`, private).
 
-## 2. O problema que resolve
+## 2. The problem it solves
 
-A operação de uma rede social de campus gera necessidades administrativas contínuas:
+Operating a campus social network creates continuous administrative needs:
 
-- **Moderação:** revisar denúncias (reports) de conteúdo/usuários, banir/desbanir estudantes,
-  acompanhar histórico de moderação (Report Safety, Report History).
-- **Gestão de estudantes:** ver estudantes ativos, banidos, desativados e "desengajados"; atualizar
-  status; exportar listas.
-- **Gestão de conteúdo:** administrar Events, Spaces e Ideas criados pelos estudantes (editar,
-  remover, exportar).
-- **Analytics operacional:** 6 dashboards (Engagement, Popular Features, User Interactions,
-  Community, Student Safety, Student Behavior) para acompanhar a saúde de cada campus.
-- **Configuração de campus:** geofences, embaixadores (ambassadors), gestão de roles/administradores.
+- **Moderation:** review content/user reports, ban/unban students,
+  track moderation history (Report Safety, Report History).
+- **Student management:** view active, banned, deactivated, and "disengaged" students; update
+  status; export lists.
+- **Content management:** administer Events, Spaces, and Ideas created by students (edit,
+  remove, export).
+- **Operational analytics:** 6 dashboards (Engagement, Popular Features, User Interactions,
+  Community, Student Safety, Student Behavior) to track the health of each campus.
+- **Campus configuration:** geofences, ambassadors, role/administrator management.
 
-Sem esse painel, essas tarefas exigiriam acesso direto ao banco/API. O admin encapsula tudo numa
-interface com **RBAC** (controle de acesso por papel) que limita o que cada tipo de admin pode ver e
-fazer, e por **campus/escola** (multi-tenant).
+Without this panel, these tasks would require direct database/API access. The admin encapsulates everything in a
+single interface with **RBAC** (role-based access control) that limits what each type of admin can see and
+do, and by **campus/school** (multi-tenant).
 
-## 3. Papel no ecossistema Walky
+## 3. Role in the Walky ecosystem
 
-A plataforma Walky tem **4 repositórios**, todos em `/Volumes/SSDDEV/DEV_PROJETOS/`:
+The Walky platform has **4 repositories**, all under `/Volumes/SSDDEV/DEV_PROJETOS/`:
 
-| Repositório | Papel | Público |
+| Repository | Role | Audience |
 |-------------|-------|---------|
-| `walkyApp` | App móvel (RN/Expo) | Estudantes |
-| `walky-backend` | API REST + WebSockets (Node/Express/Mongo) | serve todos |
-| **`walky-admin`** | **Painel admin (CoreUI)** | **Admins de campus/escola, moderadores** |
-| `walky-hq` | Painel super-admin/analytics (shadcn) | Super-admins internos Walky |
+| `walkyApp` | Mobile app (RN/Expo) | Students |
+| `walky-backend` | REST API + WebSockets (Node/Express/Mongo) | serves everyone |
+| **`walky-admin`** | **Admin panel (CoreUI)** | **Campus/school admins, moderators** |
+| `walky-hq` | Super-admin/analytics panel (shadcn) | Internal Walky super-admins |
 
 ```mermaid
 flowchart TD
-    BE["walky-backend<br/>API REST + WebSockets<br/>MongoDB · Redis · Socket.io"]
+    BE["walky-backend<br/>REST API + WebSockets<br/>MongoDB · Redis · Socket.io"]
     APP["walkyApp<br/>RN / Expo"]
-    ADMIN["walky-admin<br/>React + CoreUI (ESTE REPO)"]
+    ADMIN["walky-admin<br/>React + CoreUI (THIS REPO)"]
     HQ["walky-hq<br/>React + shadcn"]
     APP --> BE
     ADMIN --> BE
     HQ --> BE
-    BE -. "swagger.json (contrato OpenAPI)" .-> ADMIN
+    BE -. "swagger.json (OpenAPI contract)" .-> ADMIN
 ```
 
-**Cliente do backend.** O admin **não fala com o banco**; consome a API REST do backend (base via
-`VITE_API_BASE_URL`, tipicamente `https://api.walkyapp.com/api` em produção ou
-`http://localhost:8080/api` em dev). Autentica via JWT Bearer (ver
-[architecture.md](./architecture.md#5-autenticação-e-rbac)).
+**Client of the backend.** The admin **does not talk to the database**; it consumes the backend's REST API (base via
+`VITE_API_BASE_URL`, typically `https://api.walkyapp.com/api` in production or
+`http://localhost:8080/api` in dev). It authenticates via JWT Bearer (see
+[architecture.md](./architecture.md#5-authentication-and-rbac)).
 
-**Tipos gerados por Swagger.** O contrato de tipos do admin é **derivado do backend**. O script
-`npm run generate:api` roda:
+**Swagger-generated types.** The admin's type contract is **derived from the backend**. The
+`npm run generate:api` script runs:
 
 ```
 npx swagger-typescript-api generate -p ../walky-backend/swagger.json -o ./src/API --axios --name WalkyAPI.ts
 ```
 
-Isso lê o `swagger.json` do repositório irmão `walky-backend` e gera o cliente Axios tipado
-`src/API/WalkyAPI.ts` (~15k linhas). **Regra de ouro do ecossistema:** mudou o contrato no backend →
-regenerar o cliente nos frontends. O `walkyApp` faz o equivalente com Orval; o `walky-hq` também usa
-tipos derivados do mesmo Swagger.
+This reads the `swagger.json` from the sibling `walky-backend` repository and generates the typed Axios client
+`src/API/WalkyAPI.ts` (~15k lines). **Golden rule of the ecosystem:** if the contract changes in the backend →
+regenerate the client in the frontends. The `walkyApp` does the equivalent with Orval; `walky-hq` also uses
+types derived from the same Swagger.
 
-**Diferença Admin vs HQ:** ambos têm sobreposição funcional (users, events, spaces, ideas, reports,
-roles, campus). A distinção é de **escopo e público**: o **admin** é operação por **campus/escola**
-(CoreUI, orientado a operação/moderação); o **HQ** é super-admin/analytics **global** (shadcn +
-Tailwind, config de entidades core da plataforma).
+**Admin vs. HQ difference:** both have functional overlap (users, events, spaces, ideas, reports,
+roles, campus). The distinction is **scope and audience**: the **admin** is per-**campus/school** operation
+(CoreUI, operation/moderation-oriented); the **HQ** is **global** super-admin/analytics (shadcn +
+Tailwind, config of the platform's core entities).
 
-## 4. Público-alvo (RBAC de roles)
+## 4. Target audience (role-based RBAC)
 
-O acesso é governado por uma **matriz de permissões** hardcoded em
-[`src/lib/permissions.ts`](../src/lib/permissions.ts). Há **5 roles** (`RoleName`):
+Access is governed by a **permission matrix** hardcoded in
+[`src/lib/permissions.ts`](../src/lib/permissions.ts). There are **5 roles** (`RoleName`):
 
-| Role interno | Nome de exibição | Escopo | Perfil de permissão |
+| Internal role | Display name | Scope | Permission profile |
 |--------------|------------------|--------|---------------------|
-| `super_admin` | Walky Admin | Todos os campi/escolas | Acesso total: dashboards+export, gestão de estudantes, CRUD de conteúdo, moderação, campuses/ambassadors, CRUD+manage de roles |
-| `school_admin` | School Admin | Uma escola (todos os campi dela) | Igual ao super_admin na prática (matriz idêntica) |
-| `campus_admin` | Campus Admin | Um campus | Igual ao super/school_admin na matriz |
-| `moderator` | Moderator | Um campus | Dashboards read-only (sem export), **sem** gestão de estudantes/admin; **poder de moderação** (Report Safety/History: read/update/export) |
-| `walky_internal` | Walky Internal | Visibilidade interna | **Read-only** em dashboards, events/spaces/ideas e campuses/ambassadors; **sem** moderação nem gestão de estudantes |
+| `super_admin` | Walky Admin | All campuses/schools | Full access: dashboards+export, student management, content CRUD, moderation, campuses/ambassadors, role CRUD+manage |
+| `school_admin` | School Admin | One school (all its campuses) | Same as super_admin in practice (identical matrix) |
+| `campus_admin` | Campus Admin | One campus | Same as super/school_admin in the matrix |
+| `moderator` | Moderator | One campus | Read-only dashboards (no export), **no** student/admin management; **moderation power** (Report Safety/History: read/update/export) |
+| `walky_internal` | Walky Internal | Internal visibility | **Read-only** on dashboards, events/spaces/ideas, and campuses/ambassadors; **no** moderation or student management |
 
-> **Nota fiel ao código:** na matriz atual (`permissionMatrix`), `super_admin`, `school_admin` e
-> `campus_admin` têm **exatamente os mesmos direitos por recurso**. A diferença real de escopo entre
-> eles é aplicada por **campus/escola** (contexts + filtros, e pelo backend), não pela matriz de
-> ações. Ver [architecture.md](./architecture.md#5-autenticação-e-rbac).
+> **Note faithful to the code:** in the current matrix (`permissionMatrix`), `super_admin`, `school_admin`, and
+> `campus_admin` have **exactly the same rights per resource**. The real scope difference between
+> them is enforced per **campus/school** (contexts + filters, and by the backend), not by the action
+> matrix. See [architecture.md](./architecture.md#5-authentication-and-rbac).
 
-**Hierarquia de atribuição de roles** (`roleHierarchy` em `permissions.ts`): quem pode criar/atribuir
-quais roles — `super_admin` → School/Campus/Moderator; `school_admin` → Campus/Moderator;
-`campus_admin` → Moderator; `moderator` e `walky_internal` → ninguém.
+**Role assignment hierarchy** (`roleHierarchy` in `permissions.ts`): who can create/assign
+which roles — `super_admin` → School/Campus/Moderator; `school_admin` → Campus/Moderator;
+`campus_admin` → Moderator; `moderator` and `walky_internal` → no one.
 
-As 6 ações possíveis (`PermissionAction`) são: `read`, `create`, `update`, `delete`, `export`,
-`manage`. Cada recurso (`PermissionResource`, ~24 recursos: dashboards, listas de estudantes,
-events, spaces, ideas, moderação, campuses, ambassadors, role_management) recebe um objeto
-`ResourcePermission` com essas 6 flags booleanas.
+The 6 possible actions (`PermissionAction`) are: `read`, `create`, `update`, `delete`, `export`,
+`manage`. Each resource (`PermissionResource`, ~24 resources: dashboards, student lists,
+events, spaces, ideas, moderation, campuses, ambassadors, role_management) receives a
+`ResourcePermission` object with these 6 boolean flags.
 
-## 5. Quem consome / o que gerencia
+## 5. Who consumes it / what it manages
 
-Os usuários do painel (admins/moderadores) gerenciam, por telas (rotas em
+Panel users (admins/moderators) manage, via screens (routes in
 [`src/routes/v2Routes.tsx`](../src/routes/v2Routes.tsx)):
 
 - **Dashboards (6):** `dashboard/engagement`, `popular-features`, `user-interactions`, `community`,
   `student-safety`, `student-behavior`.
-- **Estudantes (4 listas):** `manage-students/active | banned | deactivated | disengaged`.
+- **Students (4 lists):** `manage-students/active | banned | deactivated | disengaged`.
 - **Events:** `events` (Manager), `events/insights`, `events/check-in` (Check-In Analytics).
 - **Spaces:** `spaces` (Manager), `spaces/insights`.
 - **Ideas:** `ideas` (Manager), `ideas/insights`.
-- **Moderação:** `report-safety`, `report-history`.
-- **Administração:** `admin/campuses` (geofences), `admin/ambassadors`, `admin/role-management`,
+- **Moderation:** `report-safety`, `report-history`.
+- **Administration:** `admin/campuses` (geofences), `admin/ambassadors`, `admin/role-management`,
   `admin/settings`.
-- **Playground (14 rotas):** visualizações experimentais de dados (interest cloud/constellation/
+- **Playground (14 routes):** experimental data visualizations (interest cloud/constellation/
   chord/pyramid + "active users" spiral/heat/rings/funnel/guitar/drums/chimes/waves/orbs/galaxy),
-  várias usando Three.js.
-- **Auth (públicas):** `login`, `recover-password` / `auth/otp`, `force-password-change`.
+  several using Three.js.
+- **Auth (public):** `login`, `recover-password` / `auth/otp`, `force-password-change`.
 
-Ver o mapa completo de telas em
+See the complete screen map in
 [folder-structure.md](./folder-structure.md#pages-v2--as-telas).
 
-## 6. Stack completa (versões reais e o porquê)
+## 6. Full stack (actual versions and the rationale)
 
-Versões extraídas de [`package.json`](../package.json). Node **≥ 20** (`engines`); `.nvmrc` fixa
-**22**; Vercel builda com `NODE_VERSION: 22`.
+Versions extracted from [`package.json`](../package.json). Node **≥ 20** (`engines`); `.nvmrc` pins
+**22**; Vercel builds with `NODE_VERSION: 22`.
 
 ### Core
 
-| Lib | Versão | Por quê |
+| Lib | Version | Why |
 |-----|--------|---------|
-| **react** / **react-dom** | ^19.1.0 | Framework de UI. React 19 (última major). |
-| **typescript** | ~5.8.3 | Tipagem estática; `strict: true` em `tsconfig.app.json`. |
-| **vite** | ^7.0.4 | Bundler/dev-server rápido (ESBuild + Rollup). Substitui CRA/Webpack; HMR instantâneo. |
-| **@vitejs/plugin-react** | ^4.6.0 | Integração React (Fast Refresh) no Vite. |
-| **react-router-dom** | ^7.6.3 | Roteamento SPA. v7 com `BrowserRouter` + rotas aninhadas e `lazy` para code-splitting. |
+| **react** / **react-dom** | ^19.1.0 | UI framework. React 19 (latest major). |
+| **typescript** | ~5.8.3 | Static typing; `strict: true` in `tsconfig.app.json`. |
+| **vite** | ^7.0.4 | Fast bundler/dev-server (ESBuild + Rollup). Replaces CRA/Webpack; instant HMR. |
+| **@vitejs/plugin-react** | ^4.6.0 | React integration (Fast Refresh) in Vite. |
+| **react-router-dom** | ^7.6.3 | SPA routing. v7 with `BrowserRouter` + nested routes and `lazy` for code-splitting. |
 
 ### UI
 
-| Lib | Versão | Por quê |
+| Lib | Version | Why |
 |-----|--------|---------|
-| **@coreui/react** | ^5.7.0 | Framework de componentes de admin (dashboards, tabelas, cards, sidebar). Escolha do produto p/ padrão visual de painel. |
-| **@coreui/coreui** | ^5.4.1 | CSS/estilos base do CoreUI (importado em `main.tsx`). |
-| **@coreui/icons** / **@coreui/icons-react** | ^3.0.1 / ^2.3.0 | Ícones do CoreUI (`CIcon`). |
-| **@coreui/utils** | ^2.0.2 | Utilitários do CoreUI. |
-| **bootstrap** | ^5.3.7 | CoreUI é construído sobre Bootstrap 5. |
-| **react-bootstrap** | ^2.10.10 | Componentes Bootstrap adicionais em React. |
-| **lucide-react** | ^0.525.0 | Ícones adicionais (linha fina, usados na UI V2). |
-| **react-hot-toast** | ^2.6.0 | Notificações toast (configurado globalmente em `App.tsx`). |
-| **simplebar-react** | ^3.3.2 | Scrollbars customizadas (ex.: sidebar). |
+| **@coreui/react** | ^5.7.0 | Admin component framework (dashboards, tables, cards, sidebar). Product choice for the panel visual standard. |
+| **@coreui/coreui** | ^5.4.1 | CoreUI base CSS/styles (imported in `main.tsx`). |
+| **@coreui/icons** / **@coreui/icons-react** | ^3.0.1 / ^2.3.0 | CoreUI icons (`CIcon`). |
+| **@coreui/utils** | ^2.0.2 | CoreUI utilities. |
+| **bootstrap** | ^5.3.7 | CoreUI is built on top of Bootstrap 5. |
+| **react-bootstrap** | ^2.10.10 | Additional Bootstrap components in React. |
+| **lucide-react** | ^0.525.0 | Additional icons (thin line, used in the V2 UI). |
+| **react-hot-toast** | ^2.6.0 | Toast notifications (configured globally in `App.tsx`). |
+| **simplebar-react** | ^3.3.2 | Custom scrollbars (e.g., sidebar). |
 
-### Dados / estado
+### Data / state
 
-| Lib | Versão | Por quê |
+| Lib | Version | Why |
 |-----|--------|---------|
-| **axios** | ^1.10.0 | Cliente HTTP; usado pelo cliente gerado e pela instância raiz `src/API/index.ts` (interceptors de auth/CSRF/401/403). |
-| **@tanstack/react-query** | ^5.82.0 | Estado de servidor (cache, stale-time, retry). `staleTime 5min`, `gcTime 10min`, retry custom (pula 4xx exceto 408). |
-| **swagger-typescript-api** | (via `npx`) | Gera o cliente Axios tipado `WalkyAPI.ts` a partir do Swagger do backend. |
+| **axios** | ^1.10.0 | HTTP client; used by the generated client and the root instance `src/API/index.ts` (auth/CSRF/401/403 interceptors). |
+| **@tanstack/react-query** | ^5.82.0 | Server state (cache, stale-time, retry). `staleTime 5min`, `gcTime 10min`, custom retry (skips 4xx except 408). |
+| **swagger-typescript-api** | (via `npx`) | Generates the typed Axios client `WalkyAPI.ts` from the backend's Swagger. |
 
-> **Estado:** o admin usa **React Context + React Query** — não há Zustand/Redux. Context para estado
-> de UI/seleção (School, Campus, Theme, Dashboard, DeactivatedUser); React Query para dados remotos.
+> **State:** the admin uses **React Context + React Query** — there is no Zustand/Redux. Context for
+> UI/selection state (School, Campus, Theme, Dashboard, DeactivatedUser); React Query for remote data.
 
-### Visualização
+### Visualization
 
-| Lib | Versão | Por quê |
+| Lib | Version | Why |
 |-----|--------|---------|
-| **recharts** | ^3.4.1 | Gráficos dos dashboards (linhas, barras, pizza). |
-| **three** | ^0.182.0 | Visualizações 3D experimentais do "Playground". |
-| **@react-three/fiber** / **@react-three/drei** | ^9.4.2 / ^10.7.7 | React renderer + helpers para Three.js. |
-| **@react-google-maps/api** + **@types/google.maps** | ^2.20.7 / ^3.58.1 | Mapas (geofences de campus, seleção de área). |
+| **recharts** | ^3.4.1 | Dashboard charts (lines, bars, pie). |
+| **three** | ^0.182.0 | Experimental 3D visualizations in the "Playground". |
+| **@react-three/fiber** / **@react-three/drei** | ^9.4.2 / ^10.7.7 | React renderer + helpers for Three.js. |
+| **@react-google-maps/api** + **@types/google.maps** | ^2.20.7 / ^3.58.1 | Maps (campus geofences, area selection). |
 
-### Utilitários
+### Utilities
 
-| Lib | Versão | Por quê |
+| Lib | Version | Why |
 |-----|--------|---------|
-| **date-fns** | ^4.1.0 | Manipulação/formatação de datas. |
-| **html2canvas** + **html2pdf.js** | ^1.4.1 / ^0.12.1 | Exportação de dashboards/relatórios para PDF/imagem. |
-| **react-is** | ^19.2.0 | Peer util de introspeção de elementos React. |
+| **date-fns** | ^4.1.0 | Date manipulation/formatting. |
+| **html2canvas** + **html2pdf.js** | ^1.4.1 / ^0.12.1 | Exporting dashboards/reports to PDF/image. |
+| **react-is** | ^19.2.0 | Peer utility for React element introspection. |
 
-### Estilo
+### Styling
 
-- **CSS + Sass** (`sass` ^1.89.2). Design tokens em **CSS variables** (dual: CoreUI + tokens V2):
-  `src/styles-v2/design-tokens.css`, `theme-variables.css`, `ThemeComponents.css`, `global.css`, e a
-  versão TS `src/styles-v2/design-tokens.ts` (auto-gerada do Figma). Dark mode via
-  `data-coreui-theme` + `data-theme` + CSS vars `--app-*` (ver `ThemeProvider`).
-- **vite-plugin-svgr** ^4.5.0: importa SVGs como componentes React (`*.svg?react`).
+- **CSS + Sass** (`sass` ^1.89.2). Design tokens as **CSS variables** (dual: CoreUI + V2 tokens):
+  `src/styles-v2/design-tokens.css`, `theme-variables.css`, `ThemeComponents.css`, `global.css`, and the
+  TS version `src/styles-v2/design-tokens.ts` (auto-generated from Figma). Dark mode via
+  `data-coreui-theme` + `data-theme` + `--app-*` CSS vars (see `ThemeProvider`).
+- **vite-plugin-svgr** ^4.5.0: imports SVGs as React components (`*.svg?react`).
 
-### Testes / qualidade
+### Testing / quality
 
-| Lib | Versão | Por quê |
+| Lib | Version | Why |
 |-----|--------|---------|
-| **vitest** | ^4.0.8 | Test runner (ambiente `jsdom`, `globals: true`). Coverage V8 com **ratchet** (thresholds: stmts 80 / branches 65 / funcs 78 / lines 80). |
-| **@testing-library/react** + **/dom** + **/jest-dom** + **/user-event** | 16.x / 10.x / 6.x / 14.x | Testes de componente centrados no usuário. |
-| **msw** | ^2.14.6 | Mock de rede (Mock Service Worker) nos testes. |
-| **eslint** + **typescript-eslint** + plugins react-hooks/react-refresh | 9.x / 8.x | Lint. |
-| **husky** + **lint-staged** | 9.x / 16.x | Git hooks: em pré-commit roda `clean-build.sh` + `eslint --fix`. |
-| **scripts próprios** | — | `check:testids` (garante `data-testid`) e `check:a11y` (acessibilidade) em `scripts/`. |
+| **vitest** | ^4.0.8 | Test runner (`jsdom` environment, `globals: true`). V8 coverage with a **ratchet** (thresholds: stmts 80 / branches 65 / funcs 78 / lines 80). |
+| **@testing-library/react** + **/dom** + **/jest-dom** + **/user-event** | 16.x / 10.x / 6.x / 14.x | User-centric component tests. |
+| **msw** | ^2.14.6 | Network mocking (Mock Service Worker) in tests. |
+| **eslint** + **typescript-eslint** + react-hooks/react-refresh plugins | 9.x / 8.x | Linting. |
+| **husky** + **lint-staged** | 9.x / 16.x | Git hooks: pre-commit runs `clean-build.sh` + `eslint --fix`. |
+| **custom scripts** | — | `check:testids` (ensures `data-testid`) and `check:a11y` (accessibility) in `scripts/`. |
 
 ### Deploy
 
-- **Vercel** (`vercel.json`): framework `vite`, `outputDirectory: dist`, SPA rewrite de `/(.*)` →
+- **Vercel** (`vercel.json`): framework `vite`, `outputDirectory: dist`, SPA rewrite of `/(.*)` →
   `/index.html`, `NODE_VERSION: 22`.
 
-## 7. Variáveis de ambiente
+## 7. Environment variables
 
-Prefixo `VITE_` (expostas ao bundle). De `.env.example`:
+Prefix `VITE_` (exposed to the bundle). From `.env.example`:
 
-| Var | Obrigatória | Descrição |
+| Var | Required | Description |
 |-----|-------------|-----------|
-| `VITE_API_BASE_URL` | sim | Base da API. Prod `https://api.walkyapp.com/api`; staging `https://staging.walkyapp.com/api`; local `http://localhost:8081/api` (ou `8080/api`). Default no código: `http://localhost:8080/api`. |
-| `VITE_APP_NAME` | — | Nome exibido (ex.: `Walky Admin`). |
+| `VITE_API_BASE_URL` | yes | API base. Prod `https://api.walkyapp.com/api`; staging `https://staging.walkyapp.com/api`; local `http://localhost:8081/api` (or `8080/api`). Default in code: `http://localhost:8080/api`. |
+| `VITE_APP_NAME` | — | Display name (e.g., `Walky Admin`). |
 | `VITE_ENV` | — | `development` / `staging` / `production`. |
-| `VITE_GOOGLE_MAPS_API_KEY` | opc. | Google Maps (geofences). Comentada no example. |
-| `VITE_SENTRY_DSN` | opc. | Sentry. Comentada no example. |
+| `VITE_GOOGLE_MAPS_API_KEY` | opt. | Google Maps (geofences). Commented out in the example. |
+| `VITE_SENTRY_DSN` | opt. | Sentry. Commented out in the example. |
 
-## 8. Scripts de build/run
+## 8. Build/run scripts
 
-De [`package.json`](../package.json):
+From [`package.json`](../package.json):
 
-| Script | O que faz |
+| Script | What it does |
 |--------|-----------|
-| `npm run dev` | Vite dev server (porta padrão **5173**). |
-| `npm run build` | `tsc -b && vite build` → `dist/` (com `manualChunks`: react-vendor, coreui, charts, query). |
-| `npm run preview` | Serve o build de produção localmente. |
-| `npm run type-check` | `tsc -b` (checagem de tipos). |
-| `npm run lint` | ESLint em todo o projeto. |
+| `npm run dev` | Vite dev server (default port **5173**). |
+| `npm run build` | `tsc -b && vite build` → `dist/` (with `manualChunks`: react-vendor, coreui, charts, query). |
+| `npm run preview` | Serves the production build locally. |
+| `npm run type-check` | `tsc -b` (type checking). |
+| `npm run lint` | ESLint across the whole project. |
 | `npm run test` / `test:ui` / `test:coverage` | Vitest (watch / UI / coverage). |
-| `npm run check:testids` / `check:a11y` / `check:all` | Guardas de `data-testid`, a11y e suite completa. |
-| `npm run generate:api` | Regenera `src/API/WalkyAPI.ts` do `../walky-backend/swagger.json`. |
-| `npm run generate:icons` / `generate:images` | Geração de assets. |
+| `npm run check:testids` / `check:a11y` / `check:all` | `data-testid`, a11y, and full-suite guards. |
+| `npm run generate:api` | Regenerates `src/API/WalkyAPI.ts` from `../walky-backend/swagger.json`. |
+| `npm run generate:icons` / `generate:images` | Asset generation. |
 | `npm run clean` | `./clean-build.sh`. |
 
-Build em produção remove `console.log/info/debug` via `esbuild.pure` (mantém `warn`/`error`).
+Production builds strip `console.log/info/debug` via `esbuild.pure` (keeps `warn`/`error`).
 
 ---
 
 ## Cross-links
 
-- [Arquitetura](./architecture.md) — fluxo de dados, service layer, RBAC, decisões.
-- [Estrutura de pastas](./folder-structure.md) — cada diretório e o porquê do sufixo `-v2`.
+- [Architecture](./architecture.md) — data flow, service layer, RBAC, decisions.
+- [Folder structure](./folder-structure.md) — each directory and the rationale for the `-v2` suffix.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,262 @@
+# Walky Admin — Visão Geral
+
+> Painel administrativo da plataforma Walky. React 19 + CoreUI 5 + Vite 7. Cliente do
+> `walky-backend`, com tipos TypeScript gerados a partir do Swagger/OpenAPI do backend.
+
+## Índice
+
+- [1. Propósito](#1-propósito)
+- [2. O problema que resolve](#2-o-problema-que-resolve)
+- [3. Papel no ecossistema Walky](#3-papel-no-ecossistema-walky)
+- [4. Público-alvo (RBAC de roles)](#4-público-alvo-rbac-de-roles)
+- [5. Quem consome / o que gerencia](#5-quem-consome--o-que-gerencia)
+- [6. Stack completa (versões reais e o porquê)](#6-stack-completa-versões-reais-e-o-porquê)
+- [7. Variáveis de ambiente](#7-variáveis-de-ambiente)
+- [8. Scripts de build/run](#8-scripts-de-buildrun)
+- [Cross-links](#cross-links)
+
+---
+
+## 1. Propósito
+
+O **walky-admin** é o **painel administrativo web** da plataforma Walky — uma rede social para
+campus universitários. Ele dá a **admins de campus, admins de escola, moderadores e super-admins**
+(além de funcionários internos com visibilidade "read-only") as ferramentas operacionais para
+gerenciar a comunidade de estudantes, o conteúdo gerado por eles e a configuração de cada campus.
+
+É uma **Single Page Application (SPA)** construída com **CoreUI** (biblioteca de componentes de
+admin sobre Bootstrap 5). Todo o seu estado de servidor vem do backend Walky via HTTP; ele não tem
+banco de dados próprio.
+
+O nome do pacote em `package.json` é literalmente `admin-panel` (`version: 0.0.0`, privado).
+
+## 2. O problema que resolve
+
+A operação de uma rede social de campus gera necessidades administrativas contínuas:
+
+- **Moderação:** revisar denúncias (reports) de conteúdo/usuários, banir/desbanir estudantes,
+  acompanhar histórico de moderação (Report Safety, Report History).
+- **Gestão de estudantes:** ver estudantes ativos, banidos, desativados e "desengajados"; atualizar
+  status; exportar listas.
+- **Gestão de conteúdo:** administrar Events, Spaces e Ideas criados pelos estudantes (editar,
+  remover, exportar).
+- **Analytics operacional:** 6 dashboards (Engagement, Popular Features, User Interactions,
+  Community, Student Safety, Student Behavior) para acompanhar a saúde de cada campus.
+- **Configuração de campus:** geofences, embaixadores (ambassadors), gestão de roles/administradores.
+
+Sem esse painel, essas tarefas exigiriam acesso direto ao banco/API. O admin encapsula tudo numa
+interface com **RBAC** (controle de acesso por papel) que limita o que cada tipo de admin pode ver e
+fazer, e por **campus/escola** (multi-tenant).
+
+## 3. Papel no ecossistema Walky
+
+A plataforma Walky tem **4 repositórios**, todos em `/Volumes/SSDDEV/DEV_PROJETOS/`:
+
+| Repositório | Papel | Público |
+|-------------|-------|---------|
+| `walkyApp` | App móvel (RN/Expo) | Estudantes |
+| `walky-backend` | API REST + WebSockets (Node/Express/Mongo) | serve todos |
+| **`walky-admin`** | **Painel admin (CoreUI)** | **Admins de campus/escola, moderadores** |
+| `walky-hq` | Painel super-admin/analytics (shadcn) | Super-admins internos Walky |
+
+```mermaid
+flowchart TD
+    BE["walky-backend<br/>API REST + WebSockets<br/>MongoDB · Redis · Socket.io"]
+    APP["walkyApp<br/>RN / Expo"]
+    ADMIN["walky-admin<br/>React + CoreUI (ESTE REPO)"]
+    HQ["walky-hq<br/>React + shadcn"]
+    APP --> BE
+    ADMIN --> BE
+    HQ --> BE
+    BE -. "swagger.json (contrato OpenAPI)" .-> ADMIN
+```
+
+**Cliente do backend.** O admin **não fala com o banco**; consome a API REST do backend (base via
+`VITE_API_BASE_URL`, tipicamente `https://api.walkyapp.com/api` em produção ou
+`http://localhost:8080/api` em dev). Autentica via JWT Bearer (ver
+[architecture.md](./architecture.md#5-autenticação-e-rbac)).
+
+**Tipos gerados por Swagger.** O contrato de tipos do admin é **derivado do backend**. O script
+`npm run generate:api` roda:
+
+```
+npx swagger-typescript-api generate -p ../walky-backend/swagger.json -o ./src/API --axios --name WalkyAPI.ts
+```
+
+Isso lê o `swagger.json` do repositório irmão `walky-backend` e gera o cliente Axios tipado
+`src/API/WalkyAPI.ts` (~15k linhas). **Regra de ouro do ecossistema:** mudou o contrato no backend →
+regenerar o cliente nos frontends. O `walkyApp` faz o equivalente com Orval; o `walky-hq` também usa
+tipos derivados do mesmo Swagger.
+
+**Diferença Admin vs HQ:** ambos têm sobreposição funcional (users, events, spaces, ideas, reports,
+roles, campus). A distinção é de **escopo e público**: o **admin** é operação por **campus/escola**
+(CoreUI, orientado a operação/moderação); o **HQ** é super-admin/analytics **global** (shadcn +
+Tailwind, config de entidades core da plataforma).
+
+## 4. Público-alvo (RBAC de roles)
+
+O acesso é governado por uma **matriz de permissões** hardcoded em
+[`src/lib/permissions.ts`](../src/lib/permissions.ts). Há **5 roles** (`RoleName`):
+
+| Role interno | Nome de exibição | Escopo | Perfil de permissão |
+|--------------|------------------|--------|---------------------|
+| `super_admin` | Walky Admin | Todos os campi/escolas | Acesso total: dashboards+export, gestão de estudantes, CRUD de conteúdo, moderação, campuses/ambassadors, CRUD+manage de roles |
+| `school_admin` | School Admin | Uma escola (todos os campi dela) | Igual ao super_admin na prática (matriz idêntica) |
+| `campus_admin` | Campus Admin | Um campus | Igual ao super/school_admin na matriz |
+| `moderator` | Moderator | Um campus | Dashboards read-only (sem export), **sem** gestão de estudantes/admin; **poder de moderação** (Report Safety/History: read/update/export) |
+| `walky_internal` | Walky Internal | Visibilidade interna | **Read-only** em dashboards, events/spaces/ideas e campuses/ambassadors; **sem** moderação nem gestão de estudantes |
+
+> **Nota fiel ao código:** na matriz atual (`permissionMatrix`), `super_admin`, `school_admin` e
+> `campus_admin` têm **exatamente os mesmos direitos por recurso**. A diferença real de escopo entre
+> eles é aplicada por **campus/escola** (contexts + filtros, e pelo backend), não pela matriz de
+> ações. Ver [architecture.md](./architecture.md#5-autenticação-e-rbac).
+
+**Hierarquia de atribuição de roles** (`roleHierarchy` em `permissions.ts`): quem pode criar/atribuir
+quais roles — `super_admin` → School/Campus/Moderator; `school_admin` → Campus/Moderator;
+`campus_admin` → Moderator; `moderator` e `walky_internal` → ninguém.
+
+As 6 ações possíveis (`PermissionAction`) são: `read`, `create`, `update`, `delete`, `export`,
+`manage`. Cada recurso (`PermissionResource`, ~24 recursos: dashboards, listas de estudantes,
+events, spaces, ideas, moderação, campuses, ambassadors, role_management) recebe um objeto
+`ResourcePermission` com essas 6 flags booleanas.
+
+## 5. Quem consome / o que gerencia
+
+Os usuários do painel (admins/moderadores) gerenciam, por telas (rotas em
+[`src/routes/v2Routes.tsx`](../src/routes/v2Routes.tsx)):
+
+- **Dashboards (6):** `dashboard/engagement`, `popular-features`, `user-interactions`, `community`,
+  `student-safety`, `student-behavior`.
+- **Estudantes (4 listas):** `manage-students/active | banned | deactivated | disengaged`.
+- **Events:** `events` (Manager), `events/insights`, `events/check-in` (Check-In Analytics).
+- **Spaces:** `spaces` (Manager), `spaces/insights`.
+- **Ideas:** `ideas` (Manager), `ideas/insights`.
+- **Moderação:** `report-safety`, `report-history`.
+- **Administração:** `admin/campuses` (geofences), `admin/ambassadors`, `admin/role-management`,
+  `admin/settings`.
+- **Playground (14 rotas):** visualizações experimentais de dados (interest cloud/constellation/
+  chord/pyramid + "active users" spiral/heat/rings/funnel/guitar/drums/chimes/waves/orbs/galaxy),
+  várias usando Three.js.
+- **Auth (públicas):** `login`, `recover-password` / `auth/otp`, `force-password-change`.
+
+Ver o mapa completo de telas em
+[folder-structure.md](./folder-structure.md#pages-v2--as-telas).
+
+## 6. Stack completa (versões reais e o porquê)
+
+Versões extraídas de [`package.json`](../package.json). Node **≥ 20** (`engines`); `.nvmrc` fixa
+**22**; Vercel builda com `NODE_VERSION: 22`.
+
+### Core
+
+| Lib | Versão | Por quê |
+|-----|--------|---------|
+| **react** / **react-dom** | ^19.1.0 | Framework de UI. React 19 (última major). |
+| **typescript** | ~5.8.3 | Tipagem estática; `strict: true` em `tsconfig.app.json`. |
+| **vite** | ^7.0.4 | Bundler/dev-server rápido (ESBuild + Rollup). Substitui CRA/Webpack; HMR instantâneo. |
+| **@vitejs/plugin-react** | ^4.6.0 | Integração React (Fast Refresh) no Vite. |
+| **react-router-dom** | ^7.6.3 | Roteamento SPA. v7 com `BrowserRouter` + rotas aninhadas e `lazy` para code-splitting. |
+
+### UI
+
+| Lib | Versão | Por quê |
+|-----|--------|---------|
+| **@coreui/react** | ^5.7.0 | Framework de componentes de admin (dashboards, tabelas, cards, sidebar). Escolha do produto p/ padrão visual de painel. |
+| **@coreui/coreui** | ^5.4.1 | CSS/estilos base do CoreUI (importado em `main.tsx`). |
+| **@coreui/icons** / **@coreui/icons-react** | ^3.0.1 / ^2.3.0 | Ícones do CoreUI (`CIcon`). |
+| **@coreui/utils** | ^2.0.2 | Utilitários do CoreUI. |
+| **bootstrap** | ^5.3.7 | CoreUI é construído sobre Bootstrap 5. |
+| **react-bootstrap** | ^2.10.10 | Componentes Bootstrap adicionais em React. |
+| **lucide-react** | ^0.525.0 | Ícones adicionais (linha fina, usados na UI V2). |
+| **react-hot-toast** | ^2.6.0 | Notificações toast (configurado globalmente em `App.tsx`). |
+| **simplebar-react** | ^3.3.2 | Scrollbars customizadas (ex.: sidebar). |
+
+### Dados / estado
+
+| Lib | Versão | Por quê |
+|-----|--------|---------|
+| **axios** | ^1.10.0 | Cliente HTTP; usado pelo cliente gerado e pela instância raiz `src/API/index.ts` (interceptors de auth/CSRF/401/403). |
+| **@tanstack/react-query** | ^5.82.0 | Estado de servidor (cache, stale-time, retry). `staleTime 5min`, `gcTime 10min`, retry custom (pula 4xx exceto 408). |
+| **swagger-typescript-api** | (via `npx`) | Gera o cliente Axios tipado `WalkyAPI.ts` a partir do Swagger do backend. |
+
+> **Estado:** o admin usa **React Context + React Query** — não há Zustand/Redux. Context para estado
+> de UI/seleção (School, Campus, Theme, Dashboard, DeactivatedUser); React Query para dados remotos.
+
+### Visualização
+
+| Lib | Versão | Por quê |
+|-----|--------|---------|
+| **recharts** | ^3.4.1 | Gráficos dos dashboards (linhas, barras, pizza). |
+| **three** | ^0.182.0 | Visualizações 3D experimentais do "Playground". |
+| **@react-three/fiber** / **@react-three/drei** | ^9.4.2 / ^10.7.7 | React renderer + helpers para Three.js. |
+| **@react-google-maps/api** + **@types/google.maps** | ^2.20.7 / ^3.58.1 | Mapas (geofences de campus, seleção de área). |
+
+### Utilitários
+
+| Lib | Versão | Por quê |
+|-----|--------|---------|
+| **date-fns** | ^4.1.0 | Manipulação/formatação de datas. |
+| **html2canvas** + **html2pdf.js** | ^1.4.1 / ^0.12.1 | Exportação de dashboards/relatórios para PDF/imagem. |
+| **react-is** | ^19.2.0 | Peer util de introspeção de elementos React. |
+
+### Estilo
+
+- **CSS + Sass** (`sass` ^1.89.2). Design tokens em **CSS variables** (dual: CoreUI + tokens V2):
+  `src/styles-v2/design-tokens.css`, `theme-variables.css`, `ThemeComponents.css`, `global.css`, e a
+  versão TS `src/styles-v2/design-tokens.ts` (auto-gerada do Figma). Dark mode via
+  `data-coreui-theme` + `data-theme` + CSS vars `--app-*` (ver `ThemeProvider`).
+- **vite-plugin-svgr** ^4.5.0: importa SVGs como componentes React (`*.svg?react`).
+
+### Testes / qualidade
+
+| Lib | Versão | Por quê |
+|-----|--------|---------|
+| **vitest** | ^4.0.8 | Test runner (ambiente `jsdom`, `globals: true`). Coverage V8 com **ratchet** (thresholds: stmts 80 / branches 65 / funcs 78 / lines 80). |
+| **@testing-library/react** + **/dom** + **/jest-dom** + **/user-event** | 16.x / 10.x / 6.x / 14.x | Testes de componente centrados no usuário. |
+| **msw** | ^2.14.6 | Mock de rede (Mock Service Worker) nos testes. |
+| **eslint** + **typescript-eslint** + plugins react-hooks/react-refresh | 9.x / 8.x | Lint. |
+| **husky** + **lint-staged** | 9.x / 16.x | Git hooks: em pré-commit roda `clean-build.sh` + `eslint --fix`. |
+| **scripts próprios** | — | `check:testids` (garante `data-testid`) e `check:a11y` (acessibilidade) em `scripts/`. |
+
+### Deploy
+
+- **Vercel** (`vercel.json`): framework `vite`, `outputDirectory: dist`, SPA rewrite de `/(.*)` →
+  `/index.html`, `NODE_VERSION: 22`.
+
+## 7. Variáveis de ambiente
+
+Prefixo `VITE_` (expostas ao bundle). De `.env.example`:
+
+| Var | Obrigatória | Descrição |
+|-----|-------------|-----------|
+| `VITE_API_BASE_URL` | sim | Base da API. Prod `https://api.walkyapp.com/api`; staging `https://staging.walkyapp.com/api`; local `http://localhost:8081/api` (ou `8080/api`). Default no código: `http://localhost:8080/api`. |
+| `VITE_APP_NAME` | — | Nome exibido (ex.: `Walky Admin`). |
+| `VITE_ENV` | — | `development` / `staging` / `production`. |
+| `VITE_GOOGLE_MAPS_API_KEY` | opc. | Google Maps (geofences). Comentada no example. |
+| `VITE_SENTRY_DSN` | opc. | Sentry. Comentada no example. |
+
+## 8. Scripts de build/run
+
+De [`package.json`](../package.json):
+
+| Script | O que faz |
+|--------|-----------|
+| `npm run dev` | Vite dev server (porta padrão **5173**). |
+| `npm run build` | `tsc -b && vite build` → `dist/` (com `manualChunks`: react-vendor, coreui, charts, query). |
+| `npm run preview` | Serve o build de produção localmente. |
+| `npm run type-check` | `tsc -b` (checagem de tipos). |
+| `npm run lint` | ESLint em todo o projeto. |
+| `npm run test` / `test:ui` / `test:coverage` | Vitest (watch / UI / coverage). |
+| `npm run check:testids` / `check:a11y` / `check:all` | Guardas de `data-testid`, a11y e suite completa. |
+| `npm run generate:api` | Regenera `src/API/WalkyAPI.ts` do `../walky-backend/swagger.json`. |
+| `npm run generate:icons` / `generate:images` | Geração de assets. |
+| `npm run clean` | `./clean-build.sh`. |
+
+Build em produção remove `console.log/info/debug` via `esbuild.pure` (mantém `warn`/`error`).
+
+---
+
+## Cross-links
+
+- [Arquitetura](./architecture.md) — fluxo de dados, service layer, RBAC, decisões.
+- [Estrutura de pastas](./folder-structure.md) — cada diretório e o porquê do sufixo `-v2`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,173 +1,175 @@
 # Troubleshooting — walky-admin
 
-> Sintomas → causa → solução, baseados em pistas reais do código. Itens marcados **(inferência)**
-> não estão explicitados no código, mas seguem da configuração observada.
+> Symptom → cause → fix, based on real clues from the code. Items marked **(inference)**
+> are not spelled out in the code but follow from the observed configuration.
 
-## Índice
+## Table of Contents
 
-- [Backend errado / sem dados / CORS](#backend-errado--sem-dados--cors)
-- [401 em loop / redirect para /login](#401-em-loop--redirect-para-login)
-- [403 abrindo modal de conta desativada](#403-abrindo-modal-de-conta-desativada)
-- [Tipos da API desatualizados / faltando método](#tipos-da-api-desatualizados--faltando-método)
-- [Commit bloqueado: testids faltando](#commit-bloqueado-testids-faltando)
-- [Commit bloqueado: acessibilidade](#commit-bloqueado-acessibilidade)
-- [Dark mode não aplica / cores hardcoded](#dark-mode-não-aplica--cores-hardcoded)
-- [`console.*` reprovado no lint](#console-reprovado-no-lint)
-- [Rota some / PermissionGuard redireciona sempre](#rota-some--permissionguard-redireciona-sempre)
-- [Testes falhando: request sem mock / provider ausente](#testes-falhando-request-sem-mock--provider-ausente)
-- [Vercel: 404 ao dar refresh numa rota (SPA routing)](#vercel-404-ao-dar-refresh-numa-rota-spa-routing)
-- [`.env` editado e nada muda](#env-editado-e-nada-muda)
+- [Wrong backend / no data / CORS](#backend-errado--sem-dados--cors)
+- [401 loop / redirect to /login](#401-em-loop--redirect-para-login)
+- [403 opening the deactivated-account modal](#403-abrindo-modal-de-conta-desativada)
+- [Stale API types / missing method](#stale-api-types--missing-method)
+- [Commit blocked: missing testids](#commit-bloqueado-testids-faltando)
+- [Commit blocked: accessibility](#commit-bloqueado-acessibilidade)
+- [Dark mode not applying / hardcoded colors](#dark-mode-not-applying--hardcoded-colors)
+- [`console.*` rejected by lint](#console-reprovado-no-lint)
+- [Route disappears / PermissionGuard always redirects](#rota-some--permissionguard-redireciona-sempre)
+- [Failing tests: unmocked request / missing provider](#testes-falhando-request-sem-mock--provider-ausente)
+- [Vercel: 404 when refreshing a route (SPA routing)](#vercel-404-ao-dar-refresh-numa-rota-spa-routing)
+- [`.env` edited and nothing changes](#env-editado-e-nada-muda)
 
 Cross-links: [conventions.md](./conventions.md) · [development.md](./development.md) · [ai-reference.md](./ai-reference.md)
 
 ---
 
-## Backend errado / sem dados / CORS
+## Wrong backend / no data / CORS
 
-**Sintoma:** telas vazias, erros de rede no console, ou CORS bloqueado.
+**Symptom:** empty screens, network errors in the console, or CORS blocked.
 
-**Causa/solução:** `VITE_API_BASE_URL` (`.env`) determina o backend. O client em `src/API/index.ts`
-faz `baseURL.replace(/\/api\/?$/, "")` para o cliente OpenAPI (rotas admin já trazem `/api`; rotas
-legadas batem na raiz). Por isso **a URL deve terminar em `/api`**. Fallback quando ausente:
+**Cause/fix:** `VITE_API_BASE_URL` (`.env`) determines the backend. The client in `src/API/index.ts`
+does `baseURL.replace(/\/api\/?$/, "")` for the OpenAPI client (admin routes already include `/api`;
+legacy routes hit the root). That's why **the URL must end in `/api`**. Fallback when absent:
 `http://localhost:8080/api`.
 
-- Local: `VITE_API_BASE_URL=http://localhost:8080/api` (ou `:8081/api`) com o `walky-backend` rodando.
-- O `.env` versionado hoje aponta para **staging** (`https://staging.walkyapp.com/api`) — troque para dev local.
-- Reinicie `yarn dev` após editar `.env`.
-- **CORS (inferência):** o Axios usa `withCredentials: true` (cookies para CSRF). Se o backend local
-  não permitir a origem `http://localhost:5173` com credenciais, requests não-GET podem falhar —
-  garanta o CORS do backend liberando essa origem.
+- Local: `VITE_API_BASE_URL=http://localhost:8080/api` (or `:8081/api`) with `walky-backend` running.
+- Your local `.env` (git-ignored) may point to **staging** (`https://staging.walkyapp.com/api`); the
+  committed `.env.example` defaults to **production** (`https://api.walkyapp.com/api`). Switch to your
+  local dev backend during development.
+- Restart `yarn dev` after editing `.env`.
+- **CORS (inference):** Axios uses `withCredentials: true` (cookies for CSRF). If the local backend
+  doesn't allow the origin `http://localhost:5173` with credentials, non-GET requests may fail —
+  make sure the backend's CORS allows that origin.
 
-## 401 em loop / redirect para /login
+## 401 loop / redirect to /login
 
-**Sintoma:** volta para `/login` repetidamente, ou logout inesperado.
+**Symptom:** you keep getting sent back to `/login`, or an unexpected logout.
 
-**Causa:** os interceptors de resposta (`src/API/index.ts`) tratam **401** removendo `localStorage.token`
-e navegando para `/login` (`window.location.href = "/login"`). Auth é lido de `localStorage`
-(`token` + `user`) por `useAuth` (`src/hooks/useAuth.ts`); `AuthGuard` redireciona quem não está autenticado.
+**Cause:** the response interceptors (`src/API/index.ts`) handle **401** by removing `localStorage.token`
+and navigating to `/login` (`window.location.href = "/login"`). Auth is read from `localStorage`
+(`token` + `user`) by `useAuth` (`src/hooks/useAuth.ts`); `AuthGuard` redirects anyone not authenticated.
 
-**Solução:**
-- Token expirado/inválido → refaça login. Não há refresh automático **(inferência: não há lógica de
-  refresh nos interceptors deste repo)**; um 401 sempre desloga.
-- Se o backend local rejeita o token (segredo JWT diferente de staging/prod), gere um token no mesmo
-  backend para onde `VITE_API_BASE_URL` aponta.
-- Estado dessincronizado entre abas: `useAuth` escuta `storage` e `auth:user-updated`; limpar
-  `localStorage` e recarregar resolve estados corrompidos (`user` inválido também dispara logout).
+**Fix:**
+- Expired/invalid token → log in again. There is no automatic refresh **(inference: there is no refresh
+  logic in this repo's interceptors)**; a 401 always logs you out.
+- If the local backend rejects the token (JWT secret different from staging/prod), generate a token on the
+  same backend that `VITE_API_BASE_URL` points to.
+- State out of sync across tabs: `useAuth` listens for `storage` and `auth:user-updated`; clearing
+  `localStorage` and reloading resolves corrupted state (an invalid `user` also triggers logout).
 
-## 403 abrindo modal de conta desativada
+## 403 opening the deactivated-account modal
 
-**Sintoma:** ação retorna 403 e aparece o modal de "conta desativada".
+**Symptom:** an action returns 403 and the "deactivated account" modal appears.
 
-**Causa:** o interceptor só dispara `triggerDeactivatedModal()` quando `error.response.data.code` é
-`ACCOUNT_DEACTIVATED` ou `USER_DEACTIVATED` (`src/API/index.ts` + `src/contexts/DeactivatedUserContext`).
-403 por **falta de permissão** (código diferente) **não** abre o modal.
+**Cause:** the interceptor only fires `triggerDeactivatedModal()` when `error.response.data.code` is
+`ACCOUNT_DEACTIVATED` or `USER_DEACTIVATED` (`src/API/index.ts` + `src/contexts/DeactivatedUserContext`).
+A 403 from **lack of permission** (a different code) does **not** open the modal.
 
-**Solução:** se você não deveria estar desativado, verifique a conta no backend. Se for erro de
-permissão, cheque a role/matriz (ver seção do PermissionGuard).
+**Fix:** if you shouldn't be deactivated, check the account on the backend. If it's a permission error,
+check the role/matrix (see the PermissionGuard section).
 
-## Tipos da API desatualizados / faltando método
+## Stale API types / missing method
 
-**Sintoma:** `apiClient.api.<método>` não existe, ou tipos divergem da resposta real do backend.
+**Symptom:** `apiClient.api.<method>` doesn't exist, or the types diverge from the backend's actual response.
 
-**Causa:** `src/API/WalkyAPI.ts` é **gerado** do Swagger e pode estar velho.
+**Cause:** `src/API/WalkyAPI.ts` is **generated** from Swagger and may be out of date.
 
-**Solução:**
+**Fix:**
 ```bash
-yarn generate:api   # precisa de ../walky-backend/swagger.json atualizado
+yarn generate:api   # needs an up-to-date ../walky-backend/swagger.json
 ```
-Regenere o `swagger.json` no backend primeiro (Swagger em `http://localhost:8081/api-docs/`). Não edite
-os arquivos gerados à mão (`src/API/WalkyAPI.ts`, `Api.ts`, `data-contracts.ts`, `http-client.ts`).
+Regenerate `swagger.json` on the backend first (Swagger at `http://localhost:8081/api-docs/`). Do not
+hand-edit the generated files (`src/API/WalkyAPI.ts`, `Api.ts`, `data-contracts.ts`, `http-client.ts`).
 
-## Commit bloqueado: testids faltando
+## Commit blocked: missing testids
 
-**Sintoma:** pre-commit/CI falha com "Add data-testid to elements".
+**Symptom:** pre-commit/CI fails with "Add data-testid to elements".
 
-**Causa:** `scripts/check-test-ids.js` exige `data-testid` em `<button>`/`<input>`/`<form>` dentro de
-`src/pages-v2` e `src/components-v2`.
+**Cause:** `scripts/check-test-ids.js` requires `data-testid` on `<button>`/`<input>`/`<form>` inside
+`src/pages-v2` and `src/components-v2`.
 
-**Solução:** adicione `data-testid="descritivo"` ao elemento (ou, em componentes que abstraem o
-elemento, passe a prop de testid — ex.: `FilterDropdown testId="..."`). Rode `yarn check:testids`.
+**Fix:** add `data-testid="descriptive"` to the element (or, for components that abstract the element,
+pass the testid prop — e.g., `FilterDropdown testId="..."`). Run `yarn check:testids`.
 
-## Commit bloqueado: acessibilidade
+## Commit blocked: accessibility
 
-**Sintoma:** pre-commit/CI falha com violações WCAG.
+**Symptom:** pre-commit/CI fails with WCAG violations.
 
-**Causa:** `scripts/check-accessibility.js` varre `pages-v2`/`components-v2`/`layout-v2`.
+**Cause:** `scripts/check-accessibility.js` scans `pages-v2`/`components-v2`/`layout-v2`.
 
-**Soluções por regra:**
-- `<img>` → `alt="..."` ou `aria-hidden="true"` (decorativa).
-- `<button>` só-ícone → `aria-label="..."`.
-- `<input>`/`<select>` → `aria-label`, `aria-labelledby` ou `id` (para `<label>`).
+**Fixes by rule:**
+- `<img>` → `alt="..."` or `aria-hidden="true"` (decorative).
+- Icon-only `<button>` → `aria-label="..."`.
+- `<input>`/`<select>` → `aria-label`, `aria-labelledby`, or `id` (for `<label>`).
 - `role="radio"` → `aria-checked`; `role="tab"` → `aria-selected`; landmarks/widgets → `aria-label`.
-- Warning de foco: adicione `:focus`/`:focus-visible` no `.css` do componente.
+- Focus warning: add `:focus`/`:focus-visible` in the component's `.css`.
 
-Rode `yarn check:a11y` para ver arquivo/linha exatos.
+Run `yarn check:a11y` to see the exact file/line.
 
-## Dark mode não aplica / cores hardcoded
+## Dark mode not applying / hardcoded colors
 
-**Sintoma:** componente não muda no tema escuro.
+**Symptom:** a component doesn't change in dark theme.
 
-**Causa:** o dark mode sobrescreve tokens `--v2-*` sob `:root[data-coreui-theme="dark"]` e
-`[data-theme="dark"]` (`src/styles-v2/design-tokens.css`). Cores hardcoded no CSS não herdam.
+**Cause:** dark mode overrides `--v2-*` tokens under `:root[data-coreui-theme="dark"]` and
+`[data-theme="dark"]` (`src/styles-v2/design-tokens.css`). Colors hardcoded in CSS don't inherit.
 
-**Solução:** use as CSS variables `--v2-*` (ex.: `color: var(--v2-text-primary); background: var(--v2-bg-card);`)
-em vez de hex fixos. O `ThemeProvider` (`src/contexts/ThemeProvider.tsx`) seta `data-coreui-theme` e
-`data-theme` no `<html>` e alterna `body.dark-theme`; o `App.tsx` alterna `body.dark-mode`. Se o toggle
-não persiste, verifique `localStorage("theme")`.
+**Fix:** use the `--v2-*` CSS variables (e.g., `color: var(--v2-text-primary); background: var(--v2-bg-card);`)
+instead of fixed hex values. `ThemeProvider` (`src/contexts/ThemeProvider.tsx`) sets `data-coreui-theme`
+and `data-theme` on `<html>` and toggles `body.dark-theme`; `App.tsx` toggles `body.dark-mode`. If the
+toggle doesn't persist, check `localStorage("theme")`.
 
-## `console.*` reprovado no lint
+## `console.*` rejected by lint
 
-**Sintoma:** ESLint falha com `no-console`.
+**Symptom:** ESLint fails with `no-console`.
 
-**Causa:** regra `no-console: 'error'` (`eslint.config.js`) para não vazar PII em produção.
+**Cause:** the `no-console: 'error'` rule (`eslint.config.js`) prevents leaking PII in production.
 
-**Solução:** use `logger` de `src/lib/logger.ts` (`logger.debug/info/warn/error`). `debug`/`info` só
-saem em DEV; o build ainda remove `console.log/info/debug` (`vite.config.ts`). Só `logger.ts` pode usar
+**Fix:** use `logger` from `src/lib/logger.ts` (`logger.debug/info/warn/error`). `debug`/`info` are emitted
+only in DEV; the build still strips `console.log/info/debug` (`vite.config.ts`). Only `logger.ts` may use
 `console` (via `eslint-disable`).
 
-## Rota some / PermissionGuard redireciona sempre
+## Route disappears / PermissionGuard always redirects
 
-**Sintoma:** usuário é jogado para `/dashboard/engagement` ao abrir uma tela; ou item some da sidebar.
+**Symptom:** the user is thrown to `/dashboard/engagement` when opening a screen; or an item disappears from the sidebar.
 
-**Causa:** `PermissionGuard` (`fallback="redirect"`) checa `permissionMatrix[role][resource].read`
-(`src/lib/permissions.ts`). Se a role não tem `read` no `resource`, redireciona para `redirectTo`
-(default `/dashboard/engagement`). Ex.: `moderator`/`walky_internal` têm `noPermissions` em
+**Cause:** `PermissionGuard` (`fallback="redirect"`) checks `permissionMatrix[role][resource].read`
+(`src/lib/permissions.ts`). If the role has no `read` on the `resource`, it redirects to `redirectTo`
+(default `/dashboard/engagement`). E.g., `moderator`/`walky_internal` have `noPermissions` on
 `active_students`, etc.
 
-**Solução:**
-- Confirme a `role` do usuário (`localStorage.user`) e a linha correspondente na `permissionMatrix`.
-- Rota nova sem entrada em `routeResourceMap` é liberada por default (`canAccessRoute` retorna `true`).
-- Ao adicionar rota protegida: inclua o `resource` no union, na matriz de **todas** as roles, e em
-  `routeResourceMap`. Ver [development.md §4](./development.md#4-adicionar-uma-página-nova-rota-lazy--permissionguard).
-- Enquanto `useAuth().isLoading`, os guards renderizam `null` (evita flash) — não confunda com "página em branco".
+**Fix:**
+- Confirm the user's `role` (`localStorage.user`) and the corresponding row in the `permissionMatrix`.
+- A new route with no entry in `routeResourceMap` is allowed by default (`canAccessRoute` returns `true`).
+- When adding a protected route: include the `resource` in the union, in the matrix for **all** roles, and
+  in `routeResourceMap`. See [development.md §4](./development.md#4-adding-a-new-page-lazy-route--permissionguard).
+- While `useAuth().isLoading`, the guards render `null` (avoids flash) — don't confuse this with a "blank page".
 
-## Testes falhando: request sem mock / provider ausente
+## Failing tests: unmocked request / missing provider
 
-**Sintoma:** teste falha por request de rede real, ou hook lança "must be used within a Provider".
+**Symptom:** a test fails on a real network request, or a hook throws "must be used within a Provider".
 
-**Causa:** MSW faz requests sem handler **falharem** de propósito; e contextos exigem seus providers.
+**Cause:** MSW makes unhandled requests **fail** on purpose; and contexts require their providers.
 
-**Solução:**
-- Renderize com `renderWithProviders` (`src/test/test-utils.tsx`) — já monta Theme/School/Campus/
+**Fix:**
+- Render with `renderWithProviders` (`src/test/test-utils.tsx`) — it already mounts Theme/School/Campus/
   Dashboard/DeactivatedUser/Router/QueryClient.
-- Mocke a rota com `server.use(http.get(\`${API_BASE}/...\`, ...))` (`src/test/handlers.ts`,
-  `src/test/server.ts`). Handlers default cobrem casos comuns; override é resetado após cada teste.
-- Auth: semeie `localStorage` (`token`, `user`) antes de renderizar.
+- Mock the route with `server.use(http.get(\`${API_BASE}/...\`, ...))` (`src/test/handlers.ts`,
+  `src/test/server.ts`). The default handlers cover common cases; overrides are reset after each test.
+- Auth: seed `localStorage` (`token`, `user`) before rendering.
 
-## Vercel: 404 ao dar refresh numa rota (SPA routing)
+## Vercel: 404 when refreshing a route (SPA routing)
 
-**Sintoma:** navegar client-side funciona, mas F5 em `/events` dá 404 no deploy.
+**Symptom:** client-side navigation works, but pressing F5 on `/events` returns 404 on the deploy.
 
-**Causa/solução:** SPA precisa de rewrite para `index.html`. Já configurado em `vercel.json`
-(`"rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]`). Se hospedar fora da Vercel
-**(inferência)**, replique esse rewrite/fallback no servidor (ex.: `try_files` no Nginx). O router usa
-`BrowserRouter` (`src/main.tsx`), então paths reais precisam cair no `index.html`.
+**Cause/fix:** an SPA needs a rewrite to `index.html`. Already configured in `vercel.json`
+(`"rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]`). If you host outside Vercel
+**(inference)**, replicate that rewrite/fallback on the server (e.g., `try_files` in Nginx). The router uses
+`BrowserRouter` (`src/main.tsx`), so real paths must resolve to `index.html`.
 
-## `.env` editado e nada muda
+## `.env` edited and nothing changes
 
-**Sintoma:** mudou `VITE_*` mas o app usa o valor antigo.
+**Symptom:** you changed a `VITE_*` value but the app uses the old one.
 
-**Causa:** Vite lê env no boot e só expõe variáveis com prefixo `VITE_`.
+**Cause:** Vite reads env at boot and only exposes variables with the `VITE_` prefix.
 
-**Solução:** reinicie `yarn dev`. Confirme o prefixo `VITE_`. Em produção/preview, rebuilde
-(`yarn build`) — os valores são embutidos no bundle.
+**Fix:** restart `yarn dev`. Confirm the `VITE_` prefix. In production/preview, rebuild
+(`yarn build`) — the values are inlined into the bundle.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,173 @@
+# Troubleshooting — walky-admin
+
+> Sintomas → causa → solução, baseados em pistas reais do código. Itens marcados **(inferência)**
+> não estão explicitados no código, mas seguem da configuração observada.
+
+## Índice
+
+- [Backend errado / sem dados / CORS](#backend-errado--sem-dados--cors)
+- [401 em loop / redirect para /login](#401-em-loop--redirect-para-login)
+- [403 abrindo modal de conta desativada](#403-abrindo-modal-de-conta-desativada)
+- [Tipos da API desatualizados / faltando método](#tipos-da-api-desatualizados--faltando-método)
+- [Commit bloqueado: testids faltando](#commit-bloqueado-testids-faltando)
+- [Commit bloqueado: acessibilidade](#commit-bloqueado-acessibilidade)
+- [Dark mode não aplica / cores hardcoded](#dark-mode-não-aplica--cores-hardcoded)
+- [`console.*` reprovado no lint](#console-reprovado-no-lint)
+- [Rota some / PermissionGuard redireciona sempre](#rota-some--permissionguard-redireciona-sempre)
+- [Testes falhando: request sem mock / provider ausente](#testes-falhando-request-sem-mock--provider-ausente)
+- [Vercel: 404 ao dar refresh numa rota (SPA routing)](#vercel-404-ao-dar-refresh-numa-rota-spa-routing)
+- [`.env` editado e nada muda](#env-editado-e-nada-muda)
+
+Cross-links: [conventions.md](./conventions.md) · [development.md](./development.md) · [ai-reference.md](./ai-reference.md)
+
+---
+
+## Backend errado / sem dados / CORS
+
+**Sintoma:** telas vazias, erros de rede no console, ou CORS bloqueado.
+
+**Causa/solução:** `VITE_API_BASE_URL` (`.env`) determina o backend. O client em `src/API/index.ts`
+faz `baseURL.replace(/\/api\/?$/, "")` para o cliente OpenAPI (rotas admin já trazem `/api`; rotas
+legadas batem na raiz). Por isso **a URL deve terminar em `/api`**. Fallback quando ausente:
+`http://localhost:8080/api`.
+
+- Local: `VITE_API_BASE_URL=http://localhost:8080/api` (ou `:8081/api`) com o `walky-backend` rodando.
+- O `.env` versionado hoje aponta para **staging** (`https://staging.walkyapp.com/api`) — troque para dev local.
+- Reinicie `yarn dev` após editar `.env`.
+- **CORS (inferência):** o Axios usa `withCredentials: true` (cookies para CSRF). Se o backend local
+  não permitir a origem `http://localhost:5173` com credenciais, requests não-GET podem falhar —
+  garanta o CORS do backend liberando essa origem.
+
+## 401 em loop / redirect para /login
+
+**Sintoma:** volta para `/login` repetidamente, ou logout inesperado.
+
+**Causa:** os interceptors de resposta (`src/API/index.ts`) tratam **401** removendo `localStorage.token`
+e navegando para `/login` (`window.location.href = "/login"`). Auth é lido de `localStorage`
+(`token` + `user`) por `useAuth` (`src/hooks/useAuth.ts`); `AuthGuard` redireciona quem não está autenticado.
+
+**Solução:**
+- Token expirado/inválido → refaça login. Não há refresh automático **(inferência: não há lógica de
+  refresh nos interceptors deste repo)**; um 401 sempre desloga.
+- Se o backend local rejeita o token (segredo JWT diferente de staging/prod), gere um token no mesmo
+  backend para onde `VITE_API_BASE_URL` aponta.
+- Estado dessincronizado entre abas: `useAuth` escuta `storage` e `auth:user-updated`; limpar
+  `localStorage` e recarregar resolve estados corrompidos (`user` inválido também dispara logout).
+
+## 403 abrindo modal de conta desativada
+
+**Sintoma:** ação retorna 403 e aparece o modal de "conta desativada".
+
+**Causa:** o interceptor só dispara `triggerDeactivatedModal()` quando `error.response.data.code` é
+`ACCOUNT_DEACTIVATED` ou `USER_DEACTIVATED` (`src/API/index.ts` + `src/contexts/DeactivatedUserContext`).
+403 por **falta de permissão** (código diferente) **não** abre o modal.
+
+**Solução:** se você não deveria estar desativado, verifique a conta no backend. Se for erro de
+permissão, cheque a role/matriz (ver seção do PermissionGuard).
+
+## Tipos da API desatualizados / faltando método
+
+**Sintoma:** `apiClient.api.<método>` não existe, ou tipos divergem da resposta real do backend.
+
+**Causa:** `src/API/WalkyAPI.ts` é **gerado** do Swagger e pode estar velho.
+
+**Solução:**
+```bash
+yarn generate:api   # precisa de ../walky-backend/swagger.json atualizado
+```
+Regenere o `swagger.json` no backend primeiro (Swagger em `http://localhost:8081/api-docs/`). Não edite
+os arquivos gerados à mão (`src/API/WalkyAPI.ts`, `Api.ts`, `data-contracts.ts`, `http-client.ts`).
+
+## Commit bloqueado: testids faltando
+
+**Sintoma:** pre-commit/CI falha com "Add data-testid to elements".
+
+**Causa:** `scripts/check-test-ids.js` exige `data-testid` em `<button>`/`<input>`/`<form>` dentro de
+`src/pages-v2` e `src/components-v2`.
+
+**Solução:** adicione `data-testid="descritivo"` ao elemento (ou, em componentes que abstraem o
+elemento, passe a prop de testid — ex.: `FilterDropdown testId="..."`). Rode `yarn check:testids`.
+
+## Commit bloqueado: acessibilidade
+
+**Sintoma:** pre-commit/CI falha com violações WCAG.
+
+**Causa:** `scripts/check-accessibility.js` varre `pages-v2`/`components-v2`/`layout-v2`.
+
+**Soluções por regra:**
+- `<img>` → `alt="..."` ou `aria-hidden="true"` (decorativa).
+- `<button>` só-ícone → `aria-label="..."`.
+- `<input>`/`<select>` → `aria-label`, `aria-labelledby` ou `id` (para `<label>`).
+- `role="radio"` → `aria-checked`; `role="tab"` → `aria-selected`; landmarks/widgets → `aria-label`.
+- Warning de foco: adicione `:focus`/`:focus-visible` no `.css` do componente.
+
+Rode `yarn check:a11y` para ver arquivo/linha exatos.
+
+## Dark mode não aplica / cores hardcoded
+
+**Sintoma:** componente não muda no tema escuro.
+
+**Causa:** o dark mode sobrescreve tokens `--v2-*` sob `:root[data-coreui-theme="dark"]` e
+`[data-theme="dark"]` (`src/styles-v2/design-tokens.css`). Cores hardcoded no CSS não herdam.
+
+**Solução:** use as CSS variables `--v2-*` (ex.: `color: var(--v2-text-primary); background: var(--v2-bg-card);`)
+em vez de hex fixos. O `ThemeProvider` (`src/contexts/ThemeProvider.tsx`) seta `data-coreui-theme` e
+`data-theme` no `<html>` e alterna `body.dark-theme`; o `App.tsx` alterna `body.dark-mode`. Se o toggle
+não persiste, verifique `localStorage("theme")`.
+
+## `console.*` reprovado no lint
+
+**Sintoma:** ESLint falha com `no-console`.
+
+**Causa:** regra `no-console: 'error'` (`eslint.config.js`) para não vazar PII em produção.
+
+**Solução:** use `logger` de `src/lib/logger.ts` (`logger.debug/info/warn/error`). `debug`/`info` só
+saem em DEV; o build ainda remove `console.log/info/debug` (`vite.config.ts`). Só `logger.ts` pode usar
+`console` (via `eslint-disable`).
+
+## Rota some / PermissionGuard redireciona sempre
+
+**Sintoma:** usuário é jogado para `/dashboard/engagement` ao abrir uma tela; ou item some da sidebar.
+
+**Causa:** `PermissionGuard` (`fallback="redirect"`) checa `permissionMatrix[role][resource].read`
+(`src/lib/permissions.ts`). Se a role não tem `read` no `resource`, redireciona para `redirectTo`
+(default `/dashboard/engagement`). Ex.: `moderator`/`walky_internal` têm `noPermissions` em
+`active_students`, etc.
+
+**Solução:**
+- Confirme a `role` do usuário (`localStorage.user`) e a linha correspondente na `permissionMatrix`.
+- Rota nova sem entrada em `routeResourceMap` é liberada por default (`canAccessRoute` retorna `true`).
+- Ao adicionar rota protegida: inclua o `resource` no union, na matriz de **todas** as roles, e em
+  `routeResourceMap`. Ver [development.md §4](./development.md#4-adicionar-uma-página-nova-rota-lazy--permissionguard).
+- Enquanto `useAuth().isLoading`, os guards renderizam `null` (evita flash) — não confunda com "página em branco".
+
+## Testes falhando: request sem mock / provider ausente
+
+**Sintoma:** teste falha por request de rede real, ou hook lança "must be used within a Provider".
+
+**Causa:** MSW faz requests sem handler **falharem** de propósito; e contextos exigem seus providers.
+
+**Solução:**
+- Renderize com `renderWithProviders` (`src/test/test-utils.tsx`) — já monta Theme/School/Campus/
+  Dashboard/DeactivatedUser/Router/QueryClient.
+- Mocke a rota com `server.use(http.get(\`${API_BASE}/...\`, ...))` (`src/test/handlers.ts`,
+  `src/test/server.ts`). Handlers default cobrem casos comuns; override é resetado após cada teste.
+- Auth: semeie `localStorage` (`token`, `user`) antes de renderizar.
+
+## Vercel: 404 ao dar refresh numa rota (SPA routing)
+
+**Sintoma:** navegar client-side funciona, mas F5 em `/events` dá 404 no deploy.
+
+**Causa/solução:** SPA precisa de rewrite para `index.html`. Já configurado em `vercel.json`
+(`"rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]`). Se hospedar fora da Vercel
+**(inferência)**, replique esse rewrite/fallback no servidor (ex.: `try_files` no Nginx). O router usa
+`BrowserRouter` (`src/main.tsx`), então paths reais precisam cair no `index.html`.
+
+## `.env` editado e nada muda
+
+**Sintoma:** mudou `VITE_*` mas o app usa o valor antigo.
+
+**Causa:** Vite lê env no boot e só expõe variáveis com prefixo `VITE_`.
+
+**Solução:** reinicie `yarn dev`. Confirme o prefixo `VITE_`. Em produção/preview, rebuilde
+(`yarn build`) — os valores são embutidos no bundle.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,775 @@
+# Walky Admin — Fluxos (Workflows)
+
+> Fluxos de ponta a ponta do painel **walky-admin** (React 19 + CoreUI 5 + Vite 7), extraídos do
+> código. Cada fluxo traz um diagrama Mermaid e cita os arquivos reais que o implementam. Todo
+> estado de servidor vem do backend Walky via HTTP; o admin não tem banco próprio.
+>
+> Documento-irmão: [business-rules.md](./business-rules.md) (regras extraídas do código).
+> Ver também [overview.md](./overview.md), [integrations.md](./integrations.md),
+> [conventions.md](./conventions.md).
+
+## Índice
+
+- [1. Login / Autenticação](#1-login--autenticação)
+- [2. Sessão, sync entre abas e logout](#2-sessão-sync-entre-abas-e-logout)
+- [3. Troca forçada de senha (require_password_change)](#3-troca-forçada-de-senha-require_password_change)
+- [4. Recuperação de senha (Forgot → OTP → Reset)](#4-recuperação-de-senha-forgot--otp--reset)
+- [5. Autorização RBAC (roles → matriz → guards)](#5-autorização-rbac-roles--matriz--guards)
+- [6. Troca de escola / campus (multi-tenant)](#6-troca-de-escola--campus-multi-tenant)
+- [7. Carregamento de dashboards / analytics](#7-carregamento-de-dashboards--analytics)
+- [8. Gestão de estudantes (ban / deactivate / activate / flag)](#8-gestão-de-estudantes-ban--deactivate--activate--flag)
+- [9. Moderação de reports](#9-moderação-de-reports)
+- [10. Gestão de campus e geofences](#10-gestão-de-campus-e-geofences)
+- [11. Ambassadors](#11-ambassadors)
+- [12. Role Management / Administrator Settings / 2FA](#12-role-management--administrator-settings--2fa)
+- [Fluxos técnicos transversais](#fluxos-técnicos-transversais)
+  - [T1. Camada Axios: interceptors, CSRF, token](#t1-camada-axios-interceptors-csrf-token)
+  - [T2. Tratamento de erro 401 / 403 (ACCOUNT_DEACTIVATED)](#t2-tratamento-de-erro-401--403-account_deactivated)
+  - [T3. Cache React Query (valores reais)](#t3-cache-react-query-valores-reais)
+- [Cross-links](#cross-links)
+
+---
+
+## 1. Login / Autenticação
+
+**Arquivos:** `src/pages-v2/LoginV2/LoginV2.tsx`, `src/API/index.ts` (interceptors),
+`src/API/Api.ts` (`api.loginCreate` → `POST /api/login`), `src/hooks/useAuth.ts`.
+
+O login é feito por um formulário controlado (email/senha). Não há um "AuthProvider" central: o
+`LoginV2` chama a API diretamente, grava `token` e `user` no `localStorage` e força um
+`window.location.href = "/"` (reload) para que o `useAuth` releia o estado do storage no mount.
+
+### Regras embutidas no fluxo (de `LoginV2.tsx`)
+
+1. **Resposta `status === "not_verified"`** (mesmo com HTTP 200, ou via erro): redireciona para
+   `"/auth/otp?step=verify&email=…&phoneNumber=…"`, preservando o `+` do email
+   (`replace(/ /g, "+")`).
+2. **Sem `access_token` na resposta:** lança `Error("Token not found in response.")`.
+3. **Allowlist de role** — só entram no painel os roles:
+   `super_admin`, `walky_internal`, `school_admin`, `campus_admin`, `editor`, `moderator`, `staff`,
+   `viewer`. Caso contrário: `"Access denied: You are not authorized for the admin panel."`
+4. **Normalização de IDs:** `school_id`/`campus_id` podem vir como objeto populado; extrai `_id`/`id`.
+5. **`require_password_change === true`:** redireciona para `/force-password-change` (ver §3).
+6. **Erro `code === "USER_DEACTIVATED"`:** abre o modal de conta desativada (inline no `LoginV2`).
+7. **Outros erros:** mostra `data.message` ou `"Invalid email or password."`.
+
+```mermaid
+sequenceDiagram
+    participant U as Admin (browser)
+    participant L as LoginV2.tsx
+    participant API as apiClient.api.loginCreate<br/>(POST /api/login)
+    participant BE as walky-backend
+    participant LS as localStorage
+    participant Auth as useAuth (após reload)
+
+    U->>L: submit(email, password)
+    L->>API: loginCreate({ email, password })
+    API->>BE: POST /api/login
+    alt status == "not_verified"
+        BE-->>L: { status:"not_verified", redirect, phoneNumber }
+        L->>U: redirect /auth/otp?step=verify&…
+    else sem access_token
+        BE-->>L: 200 sem token
+        L->>U: erro "Token not found"
+    else role não autorizado
+        BE-->>L: { access_token, role: "student" }
+        L->>U: "Access denied: not authorized"
+    else USER_DEACTIVATED (erro)
+        BE-->>L: 4xx { code:"USER_DEACTIVATED" }
+        L->>U: abre modal "Account Deactivated"
+    else sucesso
+        BE-->>L: { access_token, _id, email, role, school_id, campus_id, require_password_change }
+        L->>LS: setItem("token"), setItem("user", {...})
+        alt require_password_change
+            L->>U: redirect /force-password-change
+        else
+            L->>U: window.location.href = "/"
+            U->>Auth: mount → syncUserFromStorage()
+        end
+    end
+```
+
+> **Nota:** o backend também expõe `POST /api/refresh-token` e `POST /api/logout`
+> (`api.refreshTokenCreate`, `api.logoutCreate` em `src/API/Api.ts`), **mas o admin não usa refresh
+> token**: no 401 ele simplesmente descarta o token e manda para `/login` (ver §T2). O `refresh_token`
+> retornado pelo login **não é persistido** pelo `LoginV2`.
+
+Ver a matriz de roles em [business-rules.md §1](./business-rules.md#1-matriz-de-permissões-por-role).
+
+---
+
+## 2. Sessão, sync entre abas e logout
+
+**Arquivos:** `src/hooks/useAuth.ts`, `src/layout-v2/TopbarV2/TopbarV2.tsx` (logout),
+`src/contexts/DeactivatedUserContext.tsx` (logout de conta desativada).
+
+`useAuth` é um hook **local** (não é Context): cada componente que o usa tem seu próprio estado,
+mas todos leem a mesma fonte de verdade (`localStorage`) e se sincronizam por **eventos**.
+
+### O que `useAuth` faz
+
+- No mount: `syncUserFromStorage()` lê `token` + `user` do `localStorage`. Se o `user` estiver
+  corrompido (JSON inválido), limpa `token` e `user`.
+- Escuta dois eventos e re-sincroniza:
+  - **`window "storage"`** (disparado por *outras* abas) — filtra por `key === "user" | "token" | null`.
+  - **`window "auth:user-updated"`** (evento custom disparado por `updateUser` na *mesma* aba).
+- Expõe `user`, `isAuthenticated`, `isLoading`, `hasRole(roles[])`, `isSuperAdmin/SchoolAdmin/CampusAdmin`,
+  e `updateUser(nextUser)`.
+- `updateUser(null)` = logout local (remove `user` + `token`) e dispara `auth:user-updated`.
+
+### Logout (Topbar)
+
+`TopbarV2.handleLogout` remove `token` e `user` do `localStorage` e faz
+`window.location.href = "/login"` (`src/layout-v2/TopbarV2/TopbarV2.tsx`). Note que **não** remove
+`selectedSchool`/`selectedCampus` — essas seleções persistem entre logins na mesma máquina.
+
+```mermaid
+flowchart TD
+    subgraph AbaA["Aba A"]
+        A1[updateUser / login / logout] -->|grava| LS[(localStorage: token, user)]
+        A1 -->|dispatch| EV["evento auth:user-updated"]
+        EV --> A2[useAuth.syncUserFromStorage]
+    end
+    subgraph AbaB["Aba B"]
+        LS -.->|window 'storage' event| B1[useAuth.syncUserFromStorage]
+        B1 --> B2[re-renderiza com novo user/null]
+    end
+    A2 --> A3[re-renderiza]
+```
+
+> **Assimetria conhecida:** o logout do Topbar e o da conta desativada removem chaves manualmente
+> (`token`, `user`, às vezes `refreshToken`) e forçam `window.location.href`. Só o
+> `updateUser` dispara `auth:user-updated`; um logout via `location.href` recarrega a página, então
+> o sync entre abas continua funcionando via o evento nativo `storage`.
+
+---
+
+## 3. Troca forçada de senha (require_password_change)
+
+**Arquivo:** `src/pages-v2/ForcePasswordChange/ForcePasswordChange.tsx`
+(→ `apiClient.api.adminV2SettingsPasswordUpdate`).
+
+Fluxo obrigatório quando o backend marca `require_password_change: true` no login (ex.: senha
+provisória de um admin recém-criado). A rota `/force-password-change` é **pública** no roteador
+(fora do `AuthGuard`), mas a própria página faz sua verificação de sessão.
+
+### Regras (do componente)
+
+- No mount: se não houver `token`+`user` no storage → `/login`. Se `user.require_password_change`
+  for falso → `/` (não precisa trocar). Se `user` corrompido → limpa storage e `/login`.
+- Validações do form: `newPassword === confirmPassword` e `newPassword.length >= 8`.
+- Sucesso: chama `adminV2SettingsPasswordUpdate({ currentPassword: "", newPassword })` (currentPassword
+  vazio porque é reset forçado), toast de sucesso, zera `user.require_password_change` no storage e
+  faz `window.location.href = "/"`.
+
+```mermaid
+sequenceDiagram
+    participant P as ForcePasswordChange.tsx
+    participant LS as localStorage
+    participant API as adminV2SettingsPasswordUpdate<br/>(PUT /api/admin/v2/settings/password)
+    P->>LS: lê token + user
+    alt sem sessão
+        P->>P: navigate("/login")
+    else não requer troca
+        P->>P: navigate("/")
+    else requer troca
+        P->>P: valida (match + len>=8)
+        P->>API: { currentPassword:"", newPassword }
+        API-->>P: 200
+        P->>LS: user.require_password_change = false
+        P->>P: window.location.href = "/"
+    end
+```
+
+---
+
+## 4. Recuperação de senha (Forgot → OTP → Reset)
+
+**Arquivos:** `src/pages-v2/RecoverPasswordV2/RecoverPasswordV2/RecoverPasswordV2.tsx`
+(orquestra os passos), `.../VerifyCodeStep/VerifyCodeStep.tsx`, `.../ResetPasswordStep/ResetPasswordStep.tsx`.
+Endpoints (em `src/API/Api.ts`): `api.forgotPasswordCreate` (`POST /api/forgot-password`),
+`api.verifyOtpCreate` (`POST /api/verify-otp`), `api.resetPasswordCreate` (`POST /api/reset-password`).
+
+Rotas: `/recover-password` e `/auth/otp` (ambas montam o mesmo `RecoverPasswordV2`, que decide o
+passo pela query `?step=verify`). É um fluxo de 3 passos com a mesma tela hospedeira.
+
+```mermaid
+sequenceDiagram
+    participant U as Admin
+    participant R as RecoverPasswordV2
+    participant BE as walky-backend
+
+    U->>R: informa email (step: request)
+    R->>BE: forgotPasswordCreate({ email })
+    BE-->>U: envia OTP (email/SMS)
+    U->>R: informa OTP (step: verify)
+    R->>BE: verifyOtpCreate({ email, otp })
+    BE-->>R: { verified: true }
+    U->>R: nova senha + confirmação (step: reset)
+    R->>BE: resetPasswordCreate({ email, password, password_confirmed, otp })
+    BE-->>R: 200
+    R->>U: redirect /login
+```
+
+### Validações verificadas nos componentes
+
+- **Step 1 (email):** `forgotPasswordCreate({ email })`; validação HTML5 de email.
+- **Step 2 (OTP):** `verifyOtpCreate({ email, otp })`; **OTP = exatamente 6 dígitos** (`/^\d{6}$/`),
+  trim antes de enviar. Erros do backend: `locked` (muitas tentativas — máx 6), `expired`,
+  `remainingAttempts` → mensagens "Too many failed attempts…", "…has expired…", "…N attempts remaining."
+- **Step 3 (reset):** `resetPasswordCreate({ email, otp, password, password_confirmed })`; **senha mín.
+  8 chars**, `password === confirm`. Se o backend retornar `message === "Password validation failed"`,
+  a lista de erros é mostrada em bullets. Sucesso → toast e redirect a `/login` após 2s.
+
+Resumo consolidado em [business-rules.md §7](./business-rules.md#7-validações-de-formulários).
+
+---
+
+## 5. Autorização RBAC (roles → matriz → guards)
+
+**Arquivos:** `src/lib/permissions.ts` (matriz + helpers), `src/hooks/usePermissions.ts`,
+`src/components-v2/PermissionGuard/PermissionGuard.tsx`, `src/components-v2/AuthGuard/AuthGuard.tsx`,
+`src/routes/v2Routes.tsx` (guards por rota).
+
+O RBAC é **client-side** e declarativo. A matriz completa (o que cada role pode em cada recurso)
+está em [business-rules.md §1](./business-rules.md#1-matriz-de-permissões-por-role). Aqui está o
+fluxo de decisão.
+
+### Peças
+
+- **`permissionMatrix`** (`permissions.ts`): `Record<RoleName, Record<PermissionResource, ResourcePermission>>`,
+  onde `ResourcePermission = { read, create, update, delete, export, manage }` (booleans).
+- **`hasPermission(role, resource, action)`** → lê a matriz. Role desconhecido → `noPermissions`.
+- **`usePermissions()`** deriva `userRole` de `useAuth().user?.role` e expõe `can`, `canRead`,
+  `canCreate`, `canUpdate`, `canDelete`, `canExport`, `canManage`, `canAccessPath`, e flags de role.
+- **`AuthGuard`** — protege a árvore autenticada: enquanto `isLoading` renderiza `null`; se não
+  autenticado, `Navigate to="/login"` preservando `state.from`; senão renderiza filhos.
+- **`PermissionGuard`** — protege recurso/ação: `fallback` pode ser `'hidden'` (default), `'redirect'`
+  (default para `/dashboard/engagement`) ou um React node. Também espera `isLoading` (evita redirect
+  no refresh antes do auth inicializar).
+
+### Cadeia de proteção de rota (de `App.tsx` + `v2Routes.tsx`)
+
+```mermaid
+flowchart TD
+    Nav[Navegar para /manage-students/active] --> AG{AuthGuard: autenticado?}
+    AG -- não --> Login[/Navigate /login/]
+    AG -- isLoading --> Null1[render null]
+    AG -- sim --> PG{PermissionGuard resource=active_students action=read}
+    PG -- isLoading --> Null2[render null]
+    PG -- can=true --> Page[ActiveStudents]
+    PG -- can=false, fallback=redirect --> Redir[/Navigate /dashboard/engagement/]
+```
+
+- `App.tsx`: rota `/*` é envolvida por `<AuthGuard><V2Routes/></AuthGuard>`.
+- `v2Routes.tsx`: **cada** rota de página é envolvida por `<PermissionGuard resource=… fallback="redirect">`.
+  Exceções sem guard: `admin/settings` (AdministratorSettings), redirects legados, Playground e o `*` (404).
+- **Botões/ações inline** (ex.: `ExportButton`) usam `canExport(...)` / `<PermissionGuard>` com
+  `fallback="hidden"` para simplesmente sumir quando falta permissão — visto em
+  `ActiveStudents.tsx` (`const showExport = canExport("active_students")`).
+
+> Segurança: o RBAC do admin é **apenas de UX** — a autorização real é do backend. Ver
+> [business-rules.md §5](./business-rules.md#5-regras-de-sessão-e-segurança).
+
+---
+
+## 6. Troca de escola / campus (multi-tenant)
+
+**Arquivos:** `src/contexts/SchoolContext.tsx`, `src/contexts/CampusContext.tsx`,
+`src/layout-v2/TopbarV2/TopbarV2.tsx` (seletores + fetch), `src/services/schoolService.ts`,
+`src/services/campusService.ts`. Hooks auxiliares (definidos, ver nota): `src/hooks/useSchoolFilter.ts`,
+`src/hooks/useCampusFilter.ts`.
+
+O admin é multi-tenant por **escola → campus**. `SchoolProvider` é montado no `main.tsx` (nível mais
+alto); `CampusProvider` é montado dentro de `v2Routes.tsx` (dentro da área autenticada). Ambos
+persistem a seleção em `localStorage` (`selectedSchool`, `selectedCampus`) e reidratam no mount.
+
+### Quem pode trocar o quê (de `TopbarV2.tsx`)
+
+| Role | Seletor de escola | Seletor de campus |
+|---|---|---|
+| `super_admin` | Dropdown interativo (todas as escolas via `adminV2SchoolsList`) | Dropdown (campi da escola selecionada via `adminV2CampusesList`) |
+| `school_admin` | **Read-only** (sua escola, via `schoolDetail`) | Dropdown (campi da sua escola) |
+| Demais (`campus_admin`, `moderator`, `walky_internal`, …) | Read-only | Read-only (seu campus via `campusesDetail`) |
+
+- **Auto-seleção:** ao carregar, se nenhuma escola/campus estiver selecionada, seleciona a primeira.
+  Ao trocar de escola, se o campus atual não estiver na nova lista, reseta para o primeiro (ou `null`).
+- No mobile, os seletores viram modais (`CModal`) para super_admin (escola+campus) e school_admin (campus).
+
+### Como a troca propaga para os dados
+
+Na prática, **as páginas leem `selectedSchool?._id` / `selectedCampus?._id` diretamente** e os
+incluem tanto na `queryKey` do React Query quanto nos params da chamada — ex. em
+`ActiveStudents.tsx` e nos dashboards (`Engagement.tsx`). Trocar a seleção muda a `queryKey`, o que
+dispara um refetch automático do React Query. Ver §7.
+
+```mermaid
+sequenceDiagram
+    participant U as super_admin
+    participant T as TopbarV2
+    participant SC as SchoolContext / CampusContext
+    participant LS as localStorage
+    participant Q as React Query (páginas)
+
+    U->>T: seleciona outra escola
+    T->>SC: setSelectedSchool(school)
+    SC->>LS: setItem("selectedSchool", …)
+    T->>T: useEffect refetch campuses (adminV2CampusesList)
+    T->>SC: setSelectedCampus(primeiro campus ou null)
+    SC->>LS: setItem("selectedCampus", …)
+    Note over Q: queryKey inclui selectedSchool._id / selectedCampus._id
+    Q->>Q: key mudou → refetch automático das listas/dashboards
+```
+
+> **Nota de código (verificado):** existem os hooks `useSchoolFilter` e `useCampusFilter` que
+> instalam um interceptor Axios para injetar `school_id`/`campus_id` em GET/POST/PUT/PATCH e
+> invalidar queries. **Nenhuma tela os invoca** (`grep` não encontra usos fora dos próprios
+> arquivos). O filtro multi-tenant efetivo é feito passando os IDs explicitamente nas queries. Há
+> ainda `useDashboardPrefetch` (prefetch de todos os períodos), também **não referenciado** por
+> páginas. Documentados aqui por existirem, mas marcados como **não conectados**.
+
+---
+
+## 7. Carregamento de dashboards / analytics
+
+**Arquivos:** `src/pages-v2/Dashboard/*` (6 telas), `src/contexts/DashboardContext.tsx`
+(`timePeriod`), `src/API/Api.ts` (`adminV2Dashboard*List`), `src/lib/queryClient.ts`.
+Há também um `src/services/analyticsService.ts` (métricas de campus por `campus_id`), usado por
+telas de analytics de campus/segurança.
+
+Existem 6 dashboards: Engagement, Popular Features, User Interactions, Community, Student Safety,
+Student Behavior (rotas em `v2Routes.tsx`, protegidas por `PermissionGuard`).
+
+### Padrão de fetch (ex. `Engagement.tsx`)
+
+- Lê `selectedSchool`, `selectedCampus` (contexts) e `timePeriod` (DashboardContext, default `"month"`).
+- Usa `useQuery` do React Query, com `queryKey` = `[nome, timePeriod, schoolId, campusId]`.
+- `queryFn` chama endpoints como `adminV2DashboardStatsList`, `adminV2DashboardEngagementList`,
+  `adminV2DashboardRetentionList`, `adminV2DashboardCommunityCreationList`, passando
+  `{ period, schoolId, campusId }`.
+- Trocar período/escola/campus muda a key → refetch.
+
+### `analyticsService` (métricas de campus)
+
+Camada de service que envelopa endpoints `adminCampusMetrics*` e `adminCampusAlerts*`, convertendo
+períodos (`'7d'|'30d'|'90d'|'all'` → `undefined` para `all`) e desserializando datas:
+`getSocialHealthMetrics`, `getWellbeingMetrics`, `getCampusKPIs`, `getActivityTimeline`,
+`getCampusAlerts`, `markAlertAsRead`, `markAllAlertsAsRead`.
+
+```mermaid
+flowchart LR
+    subgraph Contextos
+        SchoolCtx[selectedSchool]
+        CampusCtx[selectedCampus]
+        DashCtx[timePeriod]
+    end
+    SchoolCtx --> Key[[queryKey: nome, period, schoolId, campusId]]
+    CampusCtx --> Key
+    DashCtx --> Key
+    Key --> RQ[React Query useQuery]
+    RQ -->|cache hit fresco| UI[render instantâneo]
+    RQ -->|stale/miss| Fetch[adminV2Dashboard*List / analyticsService]
+    Fetch --> BE[(walky-backend)]
+    BE --> RQ
+```
+
+Configuração de cache: ver [§T3](#t3-cache-react-query-valores-reais).
+
+---
+
+## 8. Gestão de estudantes (ban / deactivate / activate / flag)
+
+**Arquivos de listagem:** `src/pages-v2/Campus/ActiveStudents`, `BannedStudents`,
+`DeactivatedStudents`, `DisengagedStudents` + `src/pages-v2/Campus/components/*` (StudentTable,
+StatsCard, etc.). **Modais de ação:** `src/components-v2/{BanUserModal, UnbanUserModal,
+DeactivateUserModal, ActivateUserModal, FlagUserModal, WriteNoteModal, SendPasswordResetModal,
+LogoutAllDevicesModal, StudentProfileModal}`.
+
+As listas seguem o mesmo padrão de `ActiveStudents.tsx`: `useQuery` com key incluindo
+`school/campus/página/busca/sort`, chamando `adminV2StudentsList({ status, page, limit, search,
+sortBy, sortOrder, schoolId, campusId })` + `adminV2StudentsStatsList`. Export condicionado a
+`canExport(<resource>)`.
+
+### Ações e endpoints reais (verificado)
+
+As mutations vivem nas tabelas em `src/pages-v2/Campus/components/` (`StudentTable.tsx`,
+`BannedStudentTable.tsx`, `DeactivatedStudentTable.tsx`), disparadas via `ActionDropdown`/modais e
+também a partir do `StudentProfileModal` (por callbacks `onBanUser/onDeactivateUser/onUnbanUser/onActivateUser`).
+Todas usam `useMutation` do React Query + toast + invalidação de `["students"]` (e `["studentStats"]`).
+
+| Ação | `apiClient` | Endpoint | Payload | Invalida | Toast sucesso |
+|---|---|---|---|---|---|
+| **Ban** | `api.adminV2StudentsLockSettingsUpdate(id, …)` | `PUT /api/admin/v2/students/{id}/lock-settings` | `{ isLocked:true, lockReason, lockDuration }` (dias) | `students`, `studentStats` | "Student banned successfully" |
+| **Unban** | `api.adminV2StudentsUnbanCreate(id)` | `POST /api/admin/v2/students/{id}/unban` | — | `students`, `studentStats` | "User unbanned successfully" |
+| **Deactivate** | `api.adminV2StudentsDelete(id)` | `DELETE /api/admin/v2/students/{id}` | — | `students`, `studentStats` | "Student deactivated successfully" |
+| **Activate** | `api.adminV2StudentsActivateCreate(id)` | `POST /api/admin/v2/students/{id}/activate` | — | `students`, `studentStats` | "User activated successfully" |
+| **Flag** | `api.adminV2StudentsFlagCreate(id, { reason })` | `POST /api/admin/v2/students/{id}/flag` | `{ reason }` | `students` | "Student flagged successfully" |
+| **Unflag** | `api.adminV2StudentsUnflagCreate(id)` | `POST /api/admin/v2/students/{id}/unflag` | — | `students` | "Student unflagged successfully" |
+
+Mapeamento de duração do ban (`BanUserModal` → dias): 1/3/7/14/30/90 dias; "Permanent" → **36500**.
+
+> **Atenção (divergência de código):** existe `src/services/reportService.ts` com métodos
+> `banUserFromReport`, `getBannedUsers`, `unbanUser`, `getUserBanHistory`, `removeUser` que apontam
+> para endpoints **`adminReports*` / `adminUsersBanned*` / `adminUsers…Remove`** (rotas antigas). As
+> telas de estudante **não** usam esse service — elas chamam diretamente os endpoints
+> `adminV2Students*` da tabela acima. O `reportService` é usado no fluxo de reports (ver §9) e/ou é
+> legado. Documentado como **caminho alternativo/legado**.
+
+```mermaid
+sequenceDiagram
+    participant U as Admin
+    participant Tbl as StudentTable / ActionDropdown
+    participant M as Modal (Ban/Deactivate/…)
+    participant API as apiClient.api.adminV2Students*
+    participant BE as walky-backend
+    participant RQ as React Query
+
+    U->>Tbl: abre ações de um estudante
+    Tbl->>M: abre modal (ex. BanUserModal: duração+motivo+checkbox)
+    U->>M: confirma
+    M->>API: adminV2StudentsLockSettingsUpdate(id, {isLocked, lockReason, lockDuration})
+    API->>BE: PUT /api/admin/v2/students/{id}/lock-settings
+    BE-->>API: 200
+    API->>RQ: invalidateQueries(["students"]) + ["studentStats"]
+    RQ->>BE: refetch da lista/stats
+    API->>U: toast "Student banned successfully"
+```
+
+Regras de negócio (durações de ban, quem pode banir, notificação por email na deactivate, etc.):
+[business-rules.md §3](./business-rules.md#3-regras-de-moderação-e-gestão-de-estudantes).
+
+---
+
+## 9. Moderação de reports
+
+**Arquivos:** `src/pages-v2/Moderation/{ReportSafety, ReportHistory}`,
+`src/components-v2/{ReportDetailModal, ReportDetailsModal, FlagModal, UnflagModal}`,
+`src/services/reportService.ts`.
+
+### Endpoints reais usados pela tela (verificado em `ReportSafety.tsx`)
+
+A tela `ReportSafety` usa **diretamente** os endpoints `adminV2Reports*` (via `useQuery`/`useMutation`),
+não o `reportService`. Filtros: `page`, `limit: 10`, `search`, `type` (Event/Idea/Space/Message/User,
+CSV), `status` (CSV), `sortBy: "reportDate"`, `sortOrder`, `schoolId`, `campusId`.
+**Status válidos (labels desta tela):** `Pending review | Under evaluation | Resolved | Dismissed`.
+
+| Ação | `apiClient` | Endpoint |
+|---|---|---|
+| Listar | `api.adminV2ReportsList(query)` | `GET /api/admin/v2/reports` |
+| Stats | `api.adminV2ReportsStatsList({schoolId,campusId})` | `GET /api/admin/v2/reports/stats` |
+| Detalhe | `api.adminV2ReportsDetail(id)` | `GET /api/admin/v2/reports/{id}` |
+| Mudar status | `api.adminV2ReportsStatusPartialUpdate(id, { status })` | `PATCH /api/admin/v2/reports/{id}/status` |
+| Adicionar nota | `api.adminV2ReportsNoteCreate(id, { note })` | `POST /api/admin/v2/reports/{id}/note` |
+| Flag do item denunciado | `api.adminV2{Students,Events,Ideas,Spaces}FlagCreate(id,{reason})` | `POST /api/admin/v2/{...}/{id}/flag` |
+| Unflag do item | `api.adminV2{Students,Events,Ideas,Spaces}UnflagCreate(id)` | `POST /api/admin/v2/{...}/{id}/unflag` |
+| Banir usuário do report | `api.adminV2StudentsLockSettingsUpdate(id,{isLocked,lockReason,lockDuration})` | `PUT /api/admin/v2/students/{id}/lock-settings` |
+| Desativar usuário do report | `api.adminV2StudentsDelete(id)` | `DELETE /api/admin/v2/students/{id}` |
+
+**Regra "nota obrigatória":** no `StatusDropdown`, mudar para **Resolved** ou **Dismissed** dispara
+`onNoteRequired` → abre `WriteNoteModal` (nota obrigatória, não-vazia, `maxCharacters` 500) →
+`adminV2ReportsNoteCreate` → **depois** `adminV2ReportsStatusPartialUpdate`. Outros status mudam
+direto. Invalidação: `["reports"]`, `["reportStats"]`, `["history-reports"]`, `["history-report-stats"]`.
+
+> **Divergência:** `src/services/reportService.ts` expõe `getReports/updateReportStatus/
+> banUserFromReport/bulkUpdateReports` apontando para endpoints `adminReports*` (sem `v2`) com status
+> `pending|under_review|resolved|dismissed` e `bulk action: resolve|dismiss|under_review`. **A tela
+> `ReportSafety` não usa esse service** — usa `adminV2Reports*`. O `reportService` parece ser a
+> camada antiga; documentado em [business-rules.md §3](./business-rules.md#3-regras-de-moderação-e-gestão-de-estudantes)
+> como caminho legado.
+
+```mermaid
+sequenceDiagram
+    participant M as Moderador
+    participant RS as ReportSafety
+    participant SD as StatusDropdown
+    participant WM as WriteNoteModal
+    participant API as apiClient.api.adminV2Reports*
+    participant BE as walky-backend
+
+    RS->>API: adminV2ReportsList({status, schoolId, campusId})
+    API->>BE: GET /api/admin/v2/reports
+    BE-->>RS: reports[] + stats
+    M->>SD: seleciona novo status
+    alt Resolved / Dismissed (nota obrigatória)
+        SD->>WM: onNoteRequired → abre modal
+        M->>WM: escreve nota
+        WM->>API: adminV2ReportsNoteCreate(id, {note})
+        WM->>API: adminV2ReportsStatusPartialUpdate(id, {status})
+    else outro status
+        SD->>API: adminV2ReportsStatusPartialUpdate(id, {status})
+    end
+    API->>RS: invalida ["reports"], ["reportStats"], history keys
+```
+
+Ver [business-rules.md §3](./business-rules.md#3-regras-de-moderação-e-gestão-de-estudantes) e o
+controller do backend em [docs/admin/admin-reports-controller.md](./admin/admin-reports-controller.md).
+
+---
+
+## 10. Gestão de campus e geofences
+
+**Arquivos:** `src/pages-v2/Admin/Campuses*`, `src/pages-v2/CampusBoundary/*`,
+`src/services/campusService.ts`, `src/services/campusSyncService.ts`,
+`src/services/placeService.ts`.
+
+`campusService` (confirmado) faz o CRUD de campus (`campusesList/Create/Update/Delete`), mapeando
+`_id → id`. O geofence é o campo `coordinates` (`type: "Polygon"`, `coordinates: number[][][]`).
+
+`campusSyncService` (confirmado) cuida da **sincronização de places** por boundary via Google Places:
+- `syncCampus(id)` → `adminCampusSyncSyncCreate`
+- `syncAllCampuses()` → `adminCampusSyncSyncAllCreate`
+- `getSyncLogs(params)` → `adminCampusSyncLogsList`
+- `getCampusesWithSyncStatus()` → `adminCampusSyncCampusesList`
+- `previewCampusBoundary(id)` → `adminCampusSyncCampusPreviewList` (retorna bounds/center/area/search_points)
+
+### Detalhes verificados
+
+- **Listagem** (`src/pages-v2/Admin/Campuses/Campuses.tsx`): usa `api.adminV2CampusesList({ school_id })`,
+  paginação de 10, expande cada campus para ver a boundary num mapa read-only.
+- **Geofence** (`src/pages-v2/CampusBoundary/CampusBoundary.tsx`): Google Maps (`@react-google-maps/api`,
+  libs `["places"]`). Desenho manual do polígono por cliques (mínimo **3** vértices); ao finalizar,
+  fecha o anel (repete o primeiro ponto) e gera GeoJSON `Polygon` com coords `[lng, lat]` (WGS84). O
+  polígono fica editável (arrastar vértices) e emite `onBoundaryChange`.
+  > **Nota de segurança:** a **chave do Google Maps está hardcoded** em `CampusBoundary.tsx`
+  > (`VITE_GOOGLE_MAPS_API_KEY` do `.env.example` **não** é usada). Confirma a nota de
+  > [overview.md/integrations.md](./integrations.md).
+- **Sync de places:** `previewCampusBoundary(id)` mostra bounds/center/área/search_points antes;
+  `syncCampus(id)` executa e retorna `{ places_added, places_updated, places_removed, api_calls_used,
+  sync_status }`.
+
+```mermaid
+sequenceDiagram
+    participant A as Admin (super/school)
+    participant CP as Campuses page / CampusBoundary
+    participant CS as campusService / campusSyncService
+    participant Maps as Google Maps
+    participant BE as walky-backend
+
+    A->>CP: cria/edita campus (nome, endereço, timezone, polígono)
+    CP->>Maps: desenha geofence (Polygon)
+    CP->>CS: create/update({ campus_name, coordinates, … })
+    CS->>BE: campusesCreate / campusesUpdate
+    A->>CP: "Preview boundary"
+    CP->>CS: previewCampusBoundary(id)
+    CS->>BE: adminCampusSyncCampusPreviewList
+    A->>CP: "Sync places"
+    CP->>CS: syncCampus(id)
+    CS->>BE: adminCampusSyncSyncCreate
+    BE-->>CP: { places_added, updated, removed, api_calls_used }
+```
+
+Regras/validações de campus: [business-rules.md §6](./business-rules.md#6-regras-de-campus-geofences-e-ambassadors).
+
+---
+
+## 11. Ambassadors
+
+**Arquivos:** `src/pages-v2/Admin/Ambassadors*`, `src/services/ambassadorService.ts`,
+`src/components-v2/{AddAmbassadorModal, DeleteAmbassadorModal}`.
+
+`ambassadorService` (confirmado) usa o cliente `apiClient.ambassadors.*` (router legado na raiz):
+`ambassadorsList`, `ambassadorsDetail`, `ambassadorsCreate`, `ambassadorsUpdate`, `ambassadorsDelete`,
+`campusDetail(campusId)` (ambassadors por campus). `getAll` retorna `[]` em erro (fail-soft);
+`getById`/create/update/delete propagam o erro.
+
+A tela `src/pages-v2/Admin/Ambassadors/Ambassadors.tsx` na prática usa endpoints v2
+(`api.adminAmbassadorsList({ schoolId, campusId })`, `adminAmbassadorsCreate`, `adminAmbassadorsDelete`),
+enquanto o `ambassadorService` usa o router legado `apiClient.ambassadors.*`. O
+`AddAmbassadorModal` busca estudantes por nome exato via
+`api.adminV2MembersList({ search, role:"student", limit:20, exactMatch:true, schoolId, campusId })`
+e cria um ambassador por estudante selecionado com
+`{ name, email, user_id, school_id, campuses_id[] }`. Ações condicionadas a `canCreate("ambassadors")`
+e `canDelete("ambassadors")`.
+
+```mermaid
+sequenceDiagram
+    participant A as Admin
+    participant M as AddAmbassadorModal
+    participant API as apiClient.api
+    participant BE as walky-backend
+    A->>M: busca estudante por nome exato
+    M->>API: adminV2MembersList({search, role:"student", exactMatch:true})
+    API->>BE: GET /api/admin/v2/members
+    A->>M: seleciona estudante(s) e confirma
+    M->>API: adminAmbassadorsCreate({name, email, user_id, school_id, campuses_id})
+    API->>BE: POST /api/ambassadors
+    API->>A: invalida lista de ambassadors
+```
+
+Ver [business-rules.md §6](./business-rules.md#6-regras-de-campus-geofences-e-ambassadors).
+
+---
+
+## 12. Role Management / Administrator Settings / 2FA
+
+**Arquivos:** `src/pages-v2/Admin/{RoleManagement, AdministratorSettings}*`,
+`src/services/rolesService.ts`, `src/lib/permissions.ts` (hierarquia de atribuição),
+`src/components-v2/{CreateMemberModal, ChangeRoleModal, RolePermissionsModal, LogoutAllDevicesModal}`.
+Endpoints de perfil (`src/API/Api.ts`): `adminV2SettingsPasswordUpdate`,
+`adminProfile2FaEnableCreate` (`POST /api/admin/profile/2fa/enable`),
+`adminProfile2FaDisableCreate` (`POST /api/admin/profile/2fa/disable`),
+`adminProfileLogoutAllCreate` (`POST /api/admin/profile/logout-all`).
+
+`rolesService` (confirmado): `getRoles`, `getPermissions`, `getUserRoles`, `assignRole`,
+`removeRole`, `checkPermission`, `createRole`, `updateRole`, `deleteRole`, `createPermission`,
+`deletePermission`.
+
+### Hierarquia de atribuição (de `permissions.ts → roleHierarchy`)
+
+- `super_admin` pode atribuir: `school_admin`, `campus_admin`, `moderator`
+- `school_admin` pode atribuir: `campus_admin`, `moderator`
+- `campus_admin` pode atribuir: `moderator`
+- `moderator` / `walky_internal`: nada
+
+Helpers: `getAssignableRoles`, `getAssignableRoleDisplayNames`, `canAssignRole`,
+`canAssignRoleByDisplayName`.
+
+### AdministratorSettings (verificado) — 3 abas
+
+`src/pages-v2/Admin/AdministratorSettings/AdministratorSettings.tsx`.
+
+- **Personal Information:** `api.adminProfileList()` (carregar), `api.adminV2SettingsProfileUpdate({ firstName, lastName, position })`, avatar via `api.adminProfileAvatarCreate({ avatar: File })` (imagem, máx 5MB). Email/nome são read-only; só `position` é editável.
+- **Security:** trocar senha via `api.adminV2SettingsPasswordUpdate({ currentPassword, newPassword })` (nova senha mín. 8, confirmar igual); toggle **2FA** via `api.adminProfile2FaEnableCreate()` / `api.adminProfile2FaDisableCreate()`; logout de todos os dispositivos via `api.adminV2SettingsLogoutAllCreate()`.
+- **Danger Zone:** pedir exclusão de conta `api.adminV2SettingsDeleteAccountCreate({ reason })`, cancelar `…DeleteAccountCancelCreate`, status `…DeleteAccountStatusList`.
+
+### RoleManagement (verificado)
+
+`src/pages-v2/Admin/RoleManagement/RoleManagement.tsx` — lista membros via
+`api.adminV2MembersList({ page, limit, search, role, sortBy, sortOrder, schoolId, campusId })`.
+Criar (`adminV2MembersCreate({ name, email, role, title, school_id, campus_id })` — gera convite por
+email), mudar role (`adminV2MembersRolePartialUpdate(id, { role })`), remover
+(`adminV2MembersDelete(id)`), reset de senha (`adminV2MembersPasswordResetCreate(id)`), ativar/desativar
+(`adminV2MembersStatusPartialUpdate(id, { isActive })`). O dropdown de role no `CreateMemberModal`/
+`ChangeRoleModal` é filtrado por `getAssignableRoleDisplayNames(userRole)`. O `RolePermissionsModal`
+mostra a matriz read/create/update/delete/export/manage por recurso.
+
+```mermaid
+flowchart TD
+    subgraph Settings["AdministratorSettings"]
+        S1[Trocar senha] --> P1[adminV2SettingsPasswordUpdate]
+        S2[Ativar/Desativar 2FA] --> P2[adminProfile2FaEnable/Disable Create]
+        S3[Logout de todos os dispositivos] --> P3[adminProfileLogoutAllCreate]
+    end
+    subgraph Roles["RoleManagement"]
+        R1[getAssignableRoles user.role] --> R2[CreateMemberModal / ChangeRoleModal]
+        R2 --> R3[rolesService.assignRole / removeRole]
+    end
+```
+
+Regras completas: [business-rules.md §5](./business-rules.md#5-regras-de-sessão-e-segurança) e
+[§1](./business-rules.md#1-matriz-de-permissões-por-role).
+
+---
+
+## Fluxos técnicos transversais
+
+### T1. Camada Axios: interceptors, CSRF, token
+
+**Arquivo:** `src/API/index.ts` (+ `src/API/http-client.ts` gerado, `src/API/WalkyAPI.ts`).
+
+Há **duas** instâncias Axios com interceptors idênticos:
+1. `API` (default export) — `axios.create({ baseURL: VITE_API_BASE_URL ?? "http://localhost:8080/api", withCredentials: true })`.
+2. `apiClient` = `new Api(new HttpClient({ baseURL: baseURL.replace(/\/api\/?$/, "") }))` — o cliente
+   gerado por Swagger. O sufixo `/api` é **removido** do baseURL porque as rotas admin já incluem
+   `/api/...` e as legadas batem na raiz (`/ambassadors`, `/campus`, …). `withCredentials = true`.
+
+**Request interceptor** (ambas as instâncias):
+- Injeta `Authorization: Bearer <token>` a partir do `localStorage.getItem("token")` (warn se ausente).
+- **CSRF em não-GET:** para métodos que não sejam `get/head/options`, procura o token CSRF em cookies
+  (`csrf_cookie_rr`, `XSRF-TOKEN`, `csrf_token`, `_csrf`, nessa ordem) e o envia em **dois** headers:
+  `X-CSRF-Token` e `X-XSRF-Token`.
+
+```mermaid
+flowchart TD
+    Req[Request sai] --> Tok{token no localStorage?}
+    Tok -- sim --> AddAuth[Authorization: Bearer token]
+    Tok -- não --> Warn[logger.warn]
+    AddAuth --> M{método é GET/HEAD/OPTIONS?}
+    Warn --> M
+    M -- sim --> Send[envia]
+    M -- não --> Csrf{cookie CSRF encontrado?}
+    Csrf -- sim --> AddCsrf[X-CSRF-Token + X-XSRF-Token]
+    Csrf -- não --> Send
+    AddCsrf --> Send
+```
+
+### T2. Tratamento de erro 401 / 403 (ACCOUNT_DEACTIVATED)
+
+**Arquivos:** `src/API/index.ts` (response interceptor), `src/contexts/DeactivatedUserContext.tsx`,
+`src/components-v2/DeactivatedUserModal/DeactivatedUserModal.tsx`, `src/layout-v2/LayoutV2.tsx`.
+
+**Response interceptor** (ambas as instâncias):
+- **401:** remove `token` do `localStorage` e, se não estiver já em `/login`, faz
+  `window.location.href = "/login"`. (Não há tentativa de refresh.)
+- **403 com `code === "ACCOUNT_DEACTIVATED"` ou `"USER_DEACTIVATED"`:** chama `triggerDeactivatedModal()`.
+  Um 403 comum (permissão) **não** abre o modal.
+
+**Ponte fora do React:** `DeactivatedUserContext` expõe `registerDeactivatedSetter(setter)` e um
+`triggerDeactivatedModal()` global. `LayoutV2` registra o setter no mount. Assim o interceptor
+(código fora da árvore React) consegue acionar o modal. O botão "Log Out" do modal limpa `token`,
+`refreshToken`, `user` e vai para `/login`.
+
+```mermaid
+sequenceDiagram
+    participant Any as Qualquer request
+    participant I as Axios response interceptor
+    participant Ctx as DeactivatedUserContext (global setter)
+    participant Layout as LayoutV2 (registra setter)
+    participant Modal as DeactivatedUserModal
+
+    Layout->>Ctx: registerDeactivatedSetter(setDeactivated)  (no mount)
+    Any->>I: resposta de erro
+    alt 401
+        I->>I: remove token
+        I->>Any: window.location.href="/login"
+    else 403 code=ACCOUNT_DEACTIVATED/USER_DEACTIVATED
+        I->>Ctx: triggerDeactivatedModal()
+        Ctx->>Modal: isDeactivated = true
+        Modal->>Any: "Log Out" → limpa storage → /login
+    else 403 comum (permissão)
+        I->>Any: rejeita (sem modal)
+    end
+```
+
+### T3. Cache React Query (valores reais)
+
+**Arquivo:** `src/lib/queryClient.ts` (+ `main.tsx` que injeta o `QueryClientProvider`).
+
+Valores **reais** do `QueryClient`:
+
+| Opção | Valor | Efeito |
+|---|---|---|
+| `queries.staleTime` | `1000 * 60 * 5` (**5 min**) | Dados considerados frescos por 5 min (sem refetch). |
+| `queries.gcTime` | `1000 * 60 * 10` (**10 min**) | Cache inativo é coletado após 10 min. |
+| `queries.retry` | função custom | **Não** re-tenta em 4xx (exceto **408**); senão até **3** tentativas. |
+| `queries.refetchOnWindowFocus` | `false` | Não refaz fetch ao focar a janela. |
+| `mutations.retry` | `1` | Mutations re-tentam 1 vez. |
+
+Há uma `queryKeys` factory (`campuses`, `campus(id)`, `students`, `geofences(campusId)`,
+`ambassadors`, `ambassador(id)`, `ambassadorsByCampus(campusId)`), embora várias telas montem keys
+inline (ex.: `["students", page, search, status, sort, schoolId, campusId]`).
+
+```mermaid
+flowchart LR
+    Q[useQuery key] --> C{no cache e fresco < 5min?}
+    C -- sim --> Hit[retorna cache, sem rede]
+    C -- não --> Fetch[queryFn → Axios]
+    Fetch -- erro 4xx exceto 408 --> NoRetry[não re-tenta]
+    Fetch -- erro 5xx/408/rede --> Retry[re-tenta até 3x]
+    Fetch -- ok --> Store[grava no cache, gcTime 10min]
+```
+
+---
+
+## Cross-links
+
+- [business-rules.md](./business-rules.md) — regras de negócio extraídas do código (matriz RBAC,
+  sessão, moderação, campus/ambassadors, validações de forms).
+- [overview.md](./overview.md) — propósito, stack, público-alvo, env vars.
+- [integrations.md](./integrations.md) — integrações e camada de API.
+- [conventions.md](./conventions.md) — convenções de código.
+- [admin/admin-reports-controller.md](./admin/admin-reports-controller.md),
+  [admin/admin-students-controller.md](./admin/admin-students-controller.md),
+  [admin/admin-dashboard-controller.md](./admin/admin-dashboard-controller.md),
+  [admin/admin-settings-controller.md](./admin/admin-settings-controller.md),
+  [admin/admin-ambassadors-controller.md](./admin/admin-ambassadors-controller.md) — contratos do backend.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,57 +1,57 @@
-# Walky Admin — Fluxos (Workflows)
+# Walky Admin — Workflows
 
-> Fluxos de ponta a ponta do painel **walky-admin** (React 19 + CoreUI 5 + Vite 7), extraídos do
-> código. Cada fluxo traz um diagrama Mermaid e cita os arquivos reais que o implementam. Todo
-> estado de servidor vem do backend Walky via HTTP; o admin não tem banco próprio.
+> End-to-end flows of the **walky-admin** panel (React 19 + CoreUI 5 + Vite 7), extracted from the
+> code. Each flow includes a Mermaid diagram and cites the actual files that implement it. All
+> server state comes from the Walky backend over HTTP; the admin has no database of its own.
 >
-> Documento-irmão: [business-rules.md](./business-rules.md) (regras extraídas do código).
-> Ver também [overview.md](./overview.md), [integrations.md](./integrations.md),
+> Companion document: [business-rules.md](./business-rules.md) (rules extracted from the code).
+> See also [overview.md](./overview.md), [integrations.md](./integrations.md),
 > [conventions.md](./conventions.md).
 
-## Índice
+## Table of Contents
 
-- [1. Login / Autenticação](#1-login--autenticação)
-- [2. Sessão, sync entre abas e logout](#2-sessão-sync-entre-abas-e-logout)
-- [3. Troca forçada de senha (require_password_change)](#3-troca-forçada-de-senha-require_password_change)
-- [4. Recuperação de senha (Forgot → OTP → Reset)](#4-recuperação-de-senha-forgot--otp--reset)
-- [5. Autorização RBAC (roles → matriz → guards)](#5-autorização-rbac-roles--matriz--guards)
-- [6. Troca de escola / campus (multi-tenant)](#6-troca-de-escola--campus-multi-tenant)
-- [7. Carregamento de dashboards / analytics](#7-carregamento-de-dashboards--analytics)
-- [8. Gestão de estudantes (ban / deactivate / activate / flag)](#8-gestão-de-estudantes-ban--deactivate--activate--flag)
-- [9. Moderação de reports](#9-moderação-de-reports)
-- [10. Gestão de campus e geofences](#10-gestão-de-campus-e-geofences)
+- [1. Login / Authentication](#1-login--authentication)
+- [2. Session, cross-tab sync, and logout](#2-session-cross-tab-sync-and-logout)
+- [3. Forced password change (require_password_change)](#3-forced-password-change-require_password_change)
+- [4. Password recovery (Forgot → OTP → Reset)](#4-password-recovery-forgot--otp--reset)
+- [5. RBAC authorization (roles → matrix → guards)](#5-rbac-authorization-roles--matrix--guards)
+- [6. Switching school / campus (multi-tenant)](#6-switching-school--campus-multi-tenant)
+- [7. Loading dashboards / analytics](#7-loading-dashboards--analytics)
+- [8. Student management (ban / deactivate / activate / flag)](#8-student-management-ban--deactivate--activate--flag)
+- [9. Report moderation](#9-report-moderation)
+- [10. Campus and geofence management](#10-campus-and-geofence-management)
 - [11. Ambassadors](#11-ambassadors)
 - [12. Role Management / Administrator Settings / 2FA](#12-role-management--administrator-settings--2fa)
-- [Fluxos técnicos transversais](#fluxos-técnicos-transversais)
-  - [T1. Camada Axios: interceptors, CSRF, token](#t1-camada-axios-interceptors-csrf-token)
-  - [T2. Tratamento de erro 401 / 403 (ACCOUNT_DEACTIVATED)](#t2-tratamento-de-erro-401--403-account_deactivated)
-  - [T3. Cache React Query (valores reais)](#t3-cache-react-query-valores-reais)
+- [Cross-cutting technical flows](#cross-cutting-technical-flows)
+  - [T1. Axios layer: interceptors, CSRF, token](#t1-axios-layer-interceptors-csrf-token)
+  - [T2. Handling 401 / 403 errors (ACCOUNT_DEACTIVATED)](#t2-handling-401--403-errors-account_deactivated)
+  - [T3. React Query cache (actual values)](#t3-react-query-cache-actual-values)
 - [Cross-links](#cross-links)
 
 ---
 
-## 1. Login / Autenticação
+## 1. Login / Authentication
 
-**Arquivos:** `src/pages-v2/LoginV2/LoginV2.tsx`, `src/API/index.ts` (interceptors),
+**Files:** `src/pages-v2/LoginV2/LoginV2.tsx`, `src/API/index.ts` (interceptors),
 `src/API/Api.ts` (`api.loginCreate` → `POST /api/login`), `src/hooks/useAuth.ts`.
 
-O login é feito por um formulário controlado (email/senha). Não há um "AuthProvider" central: o
-`LoginV2` chama a API diretamente, grava `token` e `user` no `localStorage` e força um
-`window.location.href = "/"` (reload) para que o `useAuth` releia o estado do storage no mount.
+Login is handled by a controlled form (email/password). There is no central "AuthProvider": the
+`LoginV2` calls the API directly, writes `token` and `user` to `localStorage`, and forces a
+`window.location.href = "/"` (reload) so that `useAuth` re-reads the state from storage on mount.
 
-### Regras embutidas no fluxo (de `LoginV2.tsx`)
+### Rules embedded in the flow (from `LoginV2.tsx`)
 
-1. **Resposta `status === "not_verified"`** (mesmo com HTTP 200, ou via erro): redireciona para
-   `"/auth/otp?step=verify&email=…&phoneNumber=…"`, preservando o `+` do email
+1. **Response `status === "not_verified"`** (even with HTTP 200, or via an error): redirects to
+   `"/auth/otp?step=verify&email=…&phoneNumber=…"`, preserving the `+` in the email
    (`replace(/ /g, "+")`).
-2. **Sem `access_token` na resposta:** lança `Error("Token not found in response.")`.
-3. **Allowlist de role** — só entram no painel os roles:
+2. **No `access_token` in the response:** throws `Error("Token not found in response.")`.
+3. **Role allowlist** — only these roles are allowed into the panel:
    `super_admin`, `walky_internal`, `school_admin`, `campus_admin`, `editor`, `moderator`, `staff`,
-   `viewer`. Caso contrário: `"Access denied: You are not authorized for the admin panel."`
-4. **Normalização de IDs:** `school_id`/`campus_id` podem vir como objeto populado; extrai `_id`/`id`.
-5. **`require_password_change === true`:** redireciona para `/force-password-change` (ver §3).
-6. **Erro `code === "USER_DEACTIVATED"`:** abre o modal de conta desativada (inline no `LoginV2`).
-7. **Outros erros:** mostra `data.message` ou `"Invalid email or password."`.
+   `viewer`. Otherwise: `"Access denied: You are not authorized for the admin panel."`
+4. **ID normalization:** `school_id`/`campus_id` may arrive as a populated object; extract `_id`/`id`.
+5. **`require_password_change === true`:** redirects to `/force-password-change` (see §3).
+6. **Error `code === "USER_DEACTIVATED"`:** opens the deactivated-account modal (inline in `LoginV2`).
+7. **Other errors:** shows `data.message` or `"Invalid email or password."`.
 
 ```mermaid
 sequenceDiagram
@@ -60,7 +60,7 @@ sequenceDiagram
     participant API as apiClient.api.loginCreate<br/>(POST /api/login)
     participant BE as walky-backend
     participant LS as localStorage
-    participant Auth as useAuth (após reload)
+    participant Auth as useAuth (after reload)
 
     U->>L: submit(email, password)
     L->>API: loginCreate({ email, password })
@@ -68,16 +68,16 @@ sequenceDiagram
     alt status == "not_verified"
         BE-->>L: { status:"not_verified", redirect, phoneNumber }
         L->>U: redirect /auth/otp?step=verify&…
-    else sem access_token
-        BE-->>L: 200 sem token
-        L->>U: erro "Token not found"
-    else role não autorizado
+    else no access_token
+        BE-->>L: 200 without token
+        L->>U: error "Token not found"
+    else role not authorized
         BE-->>L: { access_token, role: "student" }
         L->>U: "Access denied: not authorized"
-    else USER_DEACTIVATED (erro)
+    else USER_DEACTIVATED (error)
         BE-->>L: 4xx { code:"USER_DEACTIVATED" }
-        L->>U: abre modal "Account Deactivated"
-    else sucesso
+        L->>U: opens "Account Deactivated" modal
+    else success
         BE-->>L: { access_token, _id, email, role, school_id, campus_id, require_password_change }
         L->>LS: setItem("token"), setItem("user", {...})
         alt require_password_change
@@ -89,91 +89,91 @@ sequenceDiagram
     end
 ```
 
-> **Nota:** o backend também expõe `POST /api/refresh-token` e `POST /api/logout`
-> (`api.refreshTokenCreate`, `api.logoutCreate` em `src/API/Api.ts`), **mas o admin não usa refresh
-> token**: no 401 ele simplesmente descarta o token e manda para `/login` (ver §T2). O `refresh_token`
-> retornado pelo login **não é persistido** pelo `LoginV2`.
+> **Note:** the backend also exposes `POST /api/refresh-token` and `POST /api/logout`
+> (`api.refreshTokenCreate`, `api.logoutCreate` in `src/API/Api.ts`), **but the admin does not use a
+> refresh token**: on a 401 it simply discards the token and sends the user to `/login` (see §T2). The
+> `refresh_token` returned by login **is not persisted** by `LoginV2`.
 
-Ver a matriz de roles em [business-rules.md §1](./business-rules.md#1-matriz-de-permissões-por-role).
+See the role matrix in [business-rules.md §1](./business-rules.md#1-permission-matrix-by-role).
 
 ---
 
-## 2. Sessão, sync entre abas e logout
+## 2. Session, cross-tab sync, and logout
 
-**Arquivos:** `src/hooks/useAuth.ts`, `src/layout-v2/TopbarV2/TopbarV2.tsx` (logout),
-`src/contexts/DeactivatedUserContext.tsx` (logout de conta desativada).
+**Files:** `src/hooks/useAuth.ts`, `src/layout-v2/TopbarV2/TopbarV2.tsx` (logout),
+`src/contexts/DeactivatedUserContext.tsx` (deactivated-account logout).
 
-`useAuth` é um hook **local** (não é Context): cada componente que o usa tem seu próprio estado,
-mas todos leem a mesma fonte de verdade (`localStorage`) e se sincronizam por **eventos**.
+`useAuth` is a **local** hook (not a Context): each component that uses it has its own state, but
+they all read the same source of truth (`localStorage`) and stay in sync via **events**.
 
-### O que `useAuth` faz
+### What `useAuth` does
 
-- No mount: `syncUserFromStorage()` lê `token` + `user` do `localStorage`. Se o `user` estiver
-  corrompido (JSON inválido), limpa `token` e `user`.
-- Escuta dois eventos e re-sincroniza:
-  - **`window "storage"`** (disparado por *outras* abas) — filtra por `key === "user" | "token" | null`.
-  - **`window "auth:user-updated"`** (evento custom disparado por `updateUser` na *mesma* aba).
-- Expõe `user`, `isAuthenticated`, `isLoading`, `hasRole(roles[])`, `isSuperAdmin/SchoolAdmin/CampusAdmin`,
-  e `updateUser(nextUser)`.
-- `updateUser(null)` = logout local (remove `user` + `token`) e dispara `auth:user-updated`.
+- On mount: `syncUserFromStorage()` reads `token` + `user` from `localStorage`. If `user` is
+  corrupted (invalid JSON), it clears `token` and `user`.
+- Listens to two events and re-syncs:
+  - **`window "storage"`** (fired by *other* tabs) — filters by `key === "user" | "token" | null`.
+  - **`window "auth:user-updated"`** (custom event fired by `updateUser` in the *same* tab).
+- Exposes `user`, `isAuthenticated`, `isLoading`, `hasRole(roles[])`, `isSuperAdmin/SchoolAdmin/CampusAdmin`,
+  and `updateUser(nextUser)`.
+- `updateUser(null)` = local logout (removes `user` + `token`) and fires `auth:user-updated`.
 
 ### Logout (Topbar)
 
-`TopbarV2.handleLogout` remove `token` e `user` do `localStorage` e faz
-`window.location.href = "/login"` (`src/layout-v2/TopbarV2/TopbarV2.tsx`). Note que **não** remove
-`selectedSchool`/`selectedCampus` — essas seleções persistem entre logins na mesma máquina.
+`TopbarV2.handleLogout` removes `token` and `user` from `localStorage` and does
+`window.location.href = "/login"` (`src/layout-v2/TopbarV2/TopbarV2.tsx`). Note that it does **not**
+remove `selectedSchool`/`selectedCampus` — these selections persist across logins on the same machine.
 
 ```mermaid
 flowchart TD
-    subgraph AbaA["Aba A"]
-        A1[updateUser / login / logout] -->|grava| LS[(localStorage: token, user)]
-        A1 -->|dispatch| EV["evento auth:user-updated"]
+    subgraph TabA["Tab A"]
+        A1[updateUser / login / logout] -->|writes| LS[(localStorage: token, user)]
+        A1 -->|dispatch| EV["event auth:user-updated"]
         EV --> A2[useAuth.syncUserFromStorage]
     end
-    subgraph AbaB["Aba B"]
+    subgraph TabB["Tab B"]
         LS -.->|window 'storage' event| B1[useAuth.syncUserFromStorage]
-        B1 --> B2[re-renderiza com novo user/null]
+        B1 --> B2[re-render with new user/null]
     end
-    A2 --> A3[re-renderiza]
+    A2 --> A3[re-render]
 ```
 
-> **Assimetria conhecida:** o logout do Topbar e o da conta desativada removem chaves manualmente
-> (`token`, `user`, às vezes `refreshToken`) e forçam `window.location.href`. Só o
-> `updateUser` dispara `auth:user-updated`; um logout via `location.href` recarrega a página, então
-> o sync entre abas continua funcionando via o evento nativo `storage`.
+> **Known asymmetry:** the Topbar logout and the deactivated-account logout remove keys manually
+> (`token`, `user`, sometimes `refreshToken`) and force `window.location.href`. Only `updateUser`
+> fires `auth:user-updated`; a logout via `location.href` reloads the page, so cross-tab sync still
+> works via the native `storage` event.
 
 ---
 
-## 3. Troca forçada de senha (require_password_change)
+## 3. Forced password change (require_password_change)
 
-**Arquivo:** `src/pages-v2/ForcePasswordChange/ForcePasswordChange.tsx`
+**File:** `src/pages-v2/ForcePasswordChange/ForcePasswordChange.tsx`
 (→ `apiClient.api.adminV2SettingsPasswordUpdate`).
 
-Fluxo obrigatório quando o backend marca `require_password_change: true` no login (ex.: senha
-provisória de um admin recém-criado). A rota `/force-password-change` é **pública** no roteador
-(fora do `AuthGuard`), mas a própria página faz sua verificação de sessão.
+A mandatory flow when the backend sets `require_password_change: true` at login (e.g., a temporary
+password for a newly created admin). The `/force-password-change` route is **public** in the router
+(outside the `AuthGuard`), but the page itself performs its own session check.
 
-### Regras (do componente)
+### Rules (from the component)
 
-- No mount: se não houver `token`+`user` no storage → `/login`. Se `user.require_password_change`
-  for falso → `/` (não precisa trocar). Se `user` corrompido → limpa storage e `/login`.
-- Validações do form: `newPassword === confirmPassword` e `newPassword.length >= 8`.
-- Sucesso: chama `adminV2SettingsPasswordUpdate({ currentPassword: "", newPassword })` (currentPassword
-  vazio porque é reset forçado), toast de sucesso, zera `user.require_password_change` no storage e
-  faz `window.location.href = "/"`.
+- On mount: if there is no `token`+`user` in storage → `/login`. If `user.require_password_change`
+  is false → `/` (no change needed). If `user` is corrupted → clear storage and `/login`.
+- Form validations: `newPassword === confirmPassword` and `newPassword.length >= 8`.
+- Success: calls `adminV2SettingsPasswordUpdate({ currentPassword: "", newPassword })` (currentPassword
+  empty because it is a forced reset), success toast, resets `user.require_password_change` in storage,
+  and does `window.location.href = "/"`.
 
 ```mermaid
 sequenceDiagram
     participant P as ForcePasswordChange.tsx
     participant LS as localStorage
     participant API as adminV2SettingsPasswordUpdate<br/>(PUT /api/admin/v2/settings/password)
-    P->>LS: lê token + user
-    alt sem sessão
+    P->>LS: read token + user
+    alt no session
         P->>P: navigate("/login")
-    else não requer troca
+    else change not required
         P->>P: navigate("/")
-    else requer troca
-        P->>P: valida (match + len>=8)
+    else change required
+        P->>P: validate (match + len>=8)
         P->>API: { currentPassword:"", newPassword }
         API-->>P: 200
         P->>LS: user.require_password_change = false
@@ -183,15 +183,15 @@ sequenceDiagram
 
 ---
 
-## 4. Recuperação de senha (Forgot → OTP → Reset)
+## 4. Password recovery (Forgot → OTP → Reset)
 
-**Arquivos:** `src/pages-v2/RecoverPasswordV2/RecoverPasswordV2/RecoverPasswordV2.tsx`
-(orquestra os passos), `.../VerifyCodeStep/VerifyCodeStep.tsx`, `.../ResetPasswordStep/ResetPasswordStep.tsx`.
-Endpoints (em `src/API/Api.ts`): `api.forgotPasswordCreate` (`POST /api/forgot-password`),
+**Files:** `src/pages-v2/RecoverPasswordV2/RecoverPasswordV2/RecoverPasswordV2.tsx`
+(orchestrates the steps), `.../VerifyCodeStep/VerifyCodeStep.tsx`, `.../ResetPasswordStep/ResetPasswordStep.tsx`.
+Endpoints (in `src/API/Api.ts`): `api.forgotPasswordCreate` (`POST /api/forgot-password`),
 `api.verifyOtpCreate` (`POST /api/verify-otp`), `api.resetPasswordCreate` (`POST /api/reset-password`).
 
-Rotas: `/recover-password` e `/auth/otp` (ambas montam o mesmo `RecoverPasswordV2`, que decide o
-passo pela query `?step=verify`). É um fluxo de 3 passos com a mesma tela hospedeira.
+Routes: `/recover-password` and `/auth/otp` (both mount the same `RecoverPasswordV2`, which decides
+the step from the `?step=verify` query). It is a 3-step flow with the same host screen.
 
 ```mermaid
 sequenceDiagram
@@ -199,109 +199,110 @@ sequenceDiagram
     participant R as RecoverPasswordV2
     participant BE as walky-backend
 
-    U->>R: informa email (step: request)
+    U->>R: enters email (step: request)
     R->>BE: forgotPasswordCreate({ email })
-    BE-->>U: envia OTP (email/SMS)
-    U->>R: informa OTP (step: verify)
+    BE-->>U: sends OTP (email/SMS)
+    U->>R: enters OTP (step: verify)
     R->>BE: verifyOtpCreate({ email, otp })
     BE-->>R: { verified: true }
-    U->>R: nova senha + confirmação (step: reset)
+    U->>R: new password + confirmation (step: reset)
     R->>BE: resetPasswordCreate({ email, password, password_confirmed, otp })
     BE-->>R: 200
     R->>U: redirect /login
 ```
 
-### Validações verificadas nos componentes
+### Validations verified in the components
 
-- **Step 1 (email):** `forgotPasswordCreate({ email })`; validação HTML5 de email.
-- **Step 2 (OTP):** `verifyOtpCreate({ email, otp })`; **OTP = exatamente 6 dígitos** (`/^\d{6}$/`),
-  trim antes de enviar. Erros do backend: `locked` (muitas tentativas — máx 6), `expired`,
-  `remainingAttempts` → mensagens "Too many failed attempts…", "…has expired…", "…N attempts remaining."
-- **Step 3 (reset):** `resetPasswordCreate({ email, otp, password, password_confirmed })`; **senha mín.
-  8 chars**, `password === confirm`. Se o backend retornar `message === "Password validation failed"`,
-  a lista de erros é mostrada em bullets. Sucesso → toast e redirect a `/login` após 2s.
+- **Step 1 (email):** `forgotPasswordCreate({ email })`; HTML5 email validation.
+- **Step 2 (OTP):** `verifyOtpCreate({ email, otp })`; **OTP = exactly 6 digits** (`/^\d{6}$/`),
+  trimmed before sending. Backend errors: `locked` (too many attempts — max 6), `expired`,
+  `remainingAttempts` → messages "Too many failed attempts…", "…has expired…", "…N attempts remaining."
+- **Step 3 (reset):** `resetPasswordCreate({ email, otp, password, password_confirmed })`; **password
+  min. 8 chars**, `password === confirm`. If the backend returns `message === "Password validation failed"`,
+  the list of errors is shown as bullets. Success → toast and redirect to `/login` after 2s.
 
-Resumo consolidado em [business-rules.md §7](./business-rules.md#7-validações-de-formulários).
+Consolidated summary in [business-rules.md §7](./business-rules.md#7-form-validations).
 
 ---
 
-## 5. Autorização RBAC (roles → matriz → guards)
+## 5. RBAC authorization (roles → matrix → guards)
 
-**Arquivos:** `src/lib/permissions.ts` (matriz + helpers), `src/hooks/usePermissions.ts`,
+**Files:** `src/lib/permissions.ts` (matrix + helpers), `src/hooks/usePermissions.ts`,
 `src/components-v2/PermissionGuard/PermissionGuard.tsx`, `src/components-v2/AuthGuard/AuthGuard.tsx`,
-`src/routes/v2Routes.tsx` (guards por rota).
+`src/routes/v2Routes.tsx` (per-route guards).
 
-O RBAC é **client-side** e declarativo. A matriz completa (o que cada role pode em cada recurso)
-está em [business-rules.md §1](./business-rules.md#1-matriz-de-permissões-por-role). Aqui está o
-fluxo de decisão.
+RBAC is **client-side** and declarative. The full matrix (what each role can do on each resource)
+is in [business-rules.md §1](./business-rules.md#1-permission-matrix-by-role). Here is the decision
+flow.
 
-### Peças
+### Pieces
 
 - **`permissionMatrix`** (`permissions.ts`): `Record<RoleName, Record<PermissionResource, ResourcePermission>>`,
-  onde `ResourcePermission = { read, create, update, delete, export, manage }` (booleans).
-- **`hasPermission(role, resource, action)`** → lê a matriz. Role desconhecido → `noPermissions`.
-- **`usePermissions()`** deriva `userRole` de `useAuth().user?.role` e expõe `can`, `canRead`,
-  `canCreate`, `canUpdate`, `canDelete`, `canExport`, `canManage`, `canAccessPath`, e flags de role.
-- **`AuthGuard`** — protege a árvore autenticada: enquanto `isLoading` renderiza `null`; se não
-  autenticado, `Navigate to="/login"` preservando `state.from`; senão renderiza filhos.
-- **`PermissionGuard`** — protege recurso/ação: `fallback` pode ser `'hidden'` (default), `'redirect'`
-  (default para `/dashboard/engagement`) ou um React node. Também espera `isLoading` (evita redirect
-  no refresh antes do auth inicializar).
+  where `ResourcePermission = { read, create, update, delete, export, manage }` (booleans).
+- **`hasPermission(role, resource, action)`** → reads the matrix. Unknown role → `noPermissions`.
+- **`usePermissions()`** derives `userRole` from `useAuth().user?.role` and exposes `can`, `canRead`,
+  `canCreate`, `canUpdate`, `canDelete`, `canExport`, `canManage`, `canAccessPath`, and role flags.
+- **`AuthGuard`** — protects the authenticated tree: while `isLoading` it renders `null`; if not
+  authenticated, `Navigate to="/login"` preserving `state.from`; otherwise it renders children.
+- **`PermissionGuard`** — protects a resource/action: `fallback` can be `'hidden'` (default),
+  `'redirect'` (defaults to `/dashboard/engagement`), or a React node. It also waits for `isLoading`
+  (avoids a redirect on refresh before auth initializes).
 
-### Cadeia de proteção de rota (de `App.tsx` + `v2Routes.tsx`)
+### Route protection chain (from `App.tsx` + `v2Routes.tsx`)
 
 ```mermaid
 flowchart TD
-    Nav[Navegar para /manage-students/active] --> AG{AuthGuard: autenticado?}
-    AG -- não --> Login[/Navigate /login/]
+    Nav[Navigate to /manage-students/active] --> AG{AuthGuard: authenticated?}
+    AG -- no --> Login[/Navigate /login/]
     AG -- isLoading --> Null1[render null]
-    AG -- sim --> PG{PermissionGuard resource=active_students action=read}
+    AG -- yes --> PG{PermissionGuard resource=active_students action=read}
     PG -- isLoading --> Null2[render null]
     PG -- can=true --> Page[ActiveStudents]
     PG -- can=false, fallback=redirect --> Redir[/Navigate /dashboard/engagement/]
 ```
 
-- `App.tsx`: rota `/*` é envolvida por `<AuthGuard><V2Routes/></AuthGuard>`.
-- `v2Routes.tsx`: **cada** rota de página é envolvida por `<PermissionGuard resource=… fallback="redirect">`.
-  Exceções sem guard: `admin/settings` (AdministratorSettings), redirects legados, Playground e o `*` (404).
-- **Botões/ações inline** (ex.: `ExportButton`) usam `canExport(...)` / `<PermissionGuard>` com
-  `fallback="hidden"` para simplesmente sumir quando falta permissão — visto em
+- `App.tsx`: the `/*` route is wrapped by `<AuthGuard><V2Routes/></AuthGuard>`.
+- `v2Routes.tsx`: **every** page route is wrapped by `<PermissionGuard resource=… fallback="redirect">`.
+  Exceptions without a guard: `admin/settings` (AdministratorSettings), legacy redirects, Playground,
+  and the `*` (404).
+- **Inline buttons/actions** (e.g., `ExportButton`) use `canExport(...)` / `<PermissionGuard>` with
+  `fallback="hidden"` to simply disappear when a permission is missing — seen in
   `ActiveStudents.tsx` (`const showExport = canExport("active_students")`).
 
-> Segurança: o RBAC do admin é **apenas de UX** — a autorização real é do backend. Ver
-> [business-rules.md §5](./business-rules.md#5-regras-de-sessão-e-segurança).
+> Security: the admin's RBAC is **UX-only** — real authorization lives in the backend. See
+> [business-rules.md §5](./business-rules.md#5-session-and-security-rules).
 
 ---
 
-## 6. Troca de escola / campus (multi-tenant)
+## 6. Switching school / campus (multi-tenant)
 
-**Arquivos:** `src/contexts/SchoolContext.tsx`, `src/contexts/CampusContext.tsx`,
-`src/layout-v2/TopbarV2/TopbarV2.tsx` (seletores + fetch), `src/services/schoolService.ts`,
-`src/services/campusService.ts`. Hooks auxiliares (definidos, ver nota): `src/hooks/useSchoolFilter.ts`,
+**Files:** `src/contexts/SchoolContext.tsx`, `src/contexts/CampusContext.tsx`,
+`src/layout-v2/TopbarV2/TopbarV2.tsx` (selectors + fetch), `src/services/schoolService.ts`,
+`src/services/campusService.ts`. Helper hooks (defined, see note): `src/hooks/useSchoolFilter.ts`,
 `src/hooks/useCampusFilter.ts`.
 
-O admin é multi-tenant por **escola → campus**. `SchoolProvider` é montado no `main.tsx` (nível mais
-alto); `CampusProvider` é montado dentro de `v2Routes.tsx` (dentro da área autenticada). Ambos
-persistem a seleção em `localStorage` (`selectedSchool`, `selectedCampus`) e reidratam no mount.
+The admin is multi-tenant by **school → campus**. `SchoolProvider` is mounted in `main.tsx` (the
+top level); `CampusProvider` is mounted inside `v2Routes.tsx` (inside the authenticated area). Both
+persist the selection to `localStorage` (`selectedSchool`, `selectedCampus`) and rehydrate on mount.
 
-### Quem pode trocar o quê (de `TopbarV2.tsx`)
+### Who can change what (from `TopbarV2.tsx`)
 
-| Role | Seletor de escola | Seletor de campus |
+| Role | School selector | Campus selector |
 |---|---|---|
-| `super_admin` | Dropdown interativo (todas as escolas via `adminV2SchoolsList`) | Dropdown (campi da escola selecionada via `adminV2CampusesList`) |
-| `school_admin` | **Read-only** (sua escola, via `schoolDetail`) | Dropdown (campi da sua escola) |
-| Demais (`campus_admin`, `moderator`, `walky_internal`, …) | Read-only | Read-only (seu campus via `campusesDetail`) |
+| `super_admin` | Interactive dropdown (all schools via `adminV2SchoolsList`) | Dropdown (campuses of the selected school via `adminV2CampusesList`) |
+| `school_admin` | **Read-only** (their school, via `schoolDetail`) | Dropdown (campuses of their school) |
+| Others (`campus_admin`, `moderator`, `walky_internal`, …) | Read-only | Read-only (their campus via `campusesDetail`) |
 
-- **Auto-seleção:** ao carregar, se nenhuma escola/campus estiver selecionada, seleciona a primeira.
-  Ao trocar de escola, se o campus atual não estiver na nova lista, reseta para o primeiro (ou `null`).
-- No mobile, os seletores viram modais (`CModal`) para super_admin (escola+campus) e school_admin (campus).
+- **Auto-selection:** on load, if no school/campus is selected, the first one is selected. When
+  switching school, if the current campus is not in the new list, it resets to the first (or `null`).
+- On mobile, the selectors become modals (`CModal`) for super_admin (school+campus) and school_admin (campus).
 
-### Como a troca propaga para os dados
+### How the switch propagates to the data
 
-Na prática, **as páginas leem `selectedSchool?._id` / `selectedCampus?._id` diretamente** e os
-incluem tanto na `queryKey` do React Query quanto nos params da chamada — ex. em
-`ActiveStudents.tsx` e nos dashboards (`Engagement.tsx`). Trocar a seleção muda a `queryKey`, o que
-dispara um refetch automático do React Query. Ver §7.
+In practice, **pages read `selectedSchool?._id` / `selectedCampus?._id` directly** and include them
+in both the React Query `queryKey` and the call params — e.g., in `ActiveStudents.tsx` and in the
+dashboards (`Engagement.tsx`). Changing the selection changes the `queryKey`, which triggers an
+automatic React Query refetch. See §7.
 
 ```mermaid
 sequenceDiagram
@@ -309,111 +310,112 @@ sequenceDiagram
     participant T as TopbarV2
     participant SC as SchoolContext / CampusContext
     participant LS as localStorage
-    participant Q as React Query (páginas)
+    participant Q as React Query (pages)
 
-    U->>T: seleciona outra escola
+    U->>T: selects another school
     T->>SC: setSelectedSchool(school)
     SC->>LS: setItem("selectedSchool", …)
     T->>T: useEffect refetch campuses (adminV2CampusesList)
-    T->>SC: setSelectedCampus(primeiro campus ou null)
+    T->>SC: setSelectedCampus(first campus or null)
     SC->>LS: setItem("selectedCampus", …)
-    Note over Q: queryKey inclui selectedSchool._id / selectedCampus._id
-    Q->>Q: key mudou → refetch automático das listas/dashboards
+    Note over Q: queryKey includes selectedSchool._id / selectedCampus._id
+    Q->>Q: key changed → automatic refetch of lists/dashboards
 ```
 
-> **Nota de código (verificado):** existem os hooks `useSchoolFilter` e `useCampusFilter` que
-> instalam um interceptor Axios para injetar `school_id`/`campus_id` em GET/POST/PUT/PATCH e
-> invalidar queries. **Nenhuma tela os invoca** (`grep` não encontra usos fora dos próprios
-> arquivos). O filtro multi-tenant efetivo é feito passando os IDs explicitamente nas queries. Há
-> ainda `useDashboardPrefetch` (prefetch de todos os períodos), também **não referenciado** por
-> páginas. Documentados aqui por existirem, mas marcados como **não conectados**.
+> **Code note (verified):** the hooks `useSchoolFilter` and `useCampusFilter` exist and install an
+> Axios interceptor to inject `school_id`/`campus_id` into GET/POST/PUT/PATCH and invalidate queries.
+> **No screen invokes them** (`grep` finds no usages outside the files themselves). The effective
+> multi-tenant filter is done by passing the IDs explicitly in each query. There is also
+> `useDashboardPrefetch` (prefetch of all periods), likewise **not referenced** by any page.
+> Documented here because they exist, but flagged as **not wired up**.
 
 ---
 
-## 7. Carregamento de dashboards / analytics
+## 7. Loading dashboards / analytics
 
-**Arquivos:** `src/pages-v2/Dashboard/*` (6 telas), `src/contexts/DashboardContext.tsx`
+**Files:** `src/pages-v2/Dashboard/*` (6 screens), `src/contexts/DashboardContext.tsx`
 (`timePeriod`), `src/API/Api.ts` (`adminV2Dashboard*List`), `src/lib/queryClient.ts`.
-Há também um `src/services/analyticsService.ts` (métricas de campus por `campus_id`), usado por
-telas de analytics de campus/segurança.
+There is also a `src/services/analyticsService.ts` (campus metrics by `campus_id`), used by
+campus/safety analytics screens.
 
-Existem 6 dashboards: Engagement, Popular Features, User Interactions, Community, Student Safety,
-Student Behavior (rotas em `v2Routes.tsx`, protegidas por `PermissionGuard`).
+There are 6 dashboards: Engagement, Popular Features, User Interactions, Community, Student Safety,
+Student Behavior (routes in `v2Routes.tsx`, protected by `PermissionGuard`).
 
-### Padrão de fetch (ex. `Engagement.tsx`)
+### Fetch pattern (e.g., `Engagement.tsx`)
 
-- Lê `selectedSchool`, `selectedCampus` (contexts) e `timePeriod` (DashboardContext, default `"month"`).
-- Usa `useQuery` do React Query, com `queryKey` = `[nome, timePeriod, schoolId, campusId]`.
-- `queryFn` chama endpoints como `adminV2DashboardStatsList`, `adminV2DashboardEngagementList`,
-  `adminV2DashboardRetentionList`, `adminV2DashboardCommunityCreationList`, passando
+- Reads `selectedSchool`, `selectedCampus` (contexts) and `timePeriod` (DashboardContext, default `"month"`).
+- Uses React Query's `useQuery`, with `queryKey` = `[name, timePeriod, schoolId, campusId]`.
+- `queryFn` calls endpoints such as `adminV2DashboardStatsList`, `adminV2DashboardEngagementList`,
+  `adminV2DashboardRetentionList`, `adminV2DashboardCommunityCreationList`, passing
   `{ period, schoolId, campusId }`.
-- Trocar período/escola/campus muda a key → refetch.
+- Changing the period/school/campus changes the key → refetch.
 
-### `analyticsService` (métricas de campus)
+### `analyticsService` (campus metrics)
 
-Camada de service que envelopa endpoints `adminCampusMetrics*` e `adminCampusAlerts*`, convertendo
-períodos (`'7d'|'30d'|'90d'|'all'` → `undefined` para `all`) e desserializando datas:
+A service layer that wraps the `adminCampusMetrics*` and `adminCampusAlerts*` endpoints, converting
+periods (`'7d'|'30d'|'90d'|'all'` → `undefined` for `all`) and deserializing dates:
 `getSocialHealthMetrics`, `getWellbeingMetrics`, `getCampusKPIs`, `getActivityTimeline`,
 `getCampusAlerts`, `markAlertAsRead`, `markAllAlertsAsRead`.
 
 ```mermaid
 flowchart LR
-    subgraph Contextos
+    subgraph Contexts
         SchoolCtx[selectedSchool]
         CampusCtx[selectedCampus]
         DashCtx[timePeriod]
     end
-    SchoolCtx --> Key[[queryKey: nome, period, schoolId, campusId]]
+    SchoolCtx --> Key[[queryKey: name, period, schoolId, campusId]]
     CampusCtx --> Key
     DashCtx --> Key
     Key --> RQ[React Query useQuery]
-    RQ -->|cache hit fresco| UI[render instantâneo]
+    RQ -->|fresh cache hit| UI[instant render]
     RQ -->|stale/miss| Fetch[adminV2Dashboard*List / analyticsService]
     Fetch --> BE[(walky-backend)]
     BE --> RQ
 ```
 
-Configuração de cache: ver [§T3](#t3-cache-react-query-valores-reais).
+Cache configuration: see [§T3](#t3-react-query-cache-actual-values).
 
 ---
 
-## 8. Gestão de estudantes (ban / deactivate / activate / flag)
+## 8. Student management (ban / deactivate / activate / flag)
 
-**Arquivos de listagem:** `src/pages-v2/Campus/ActiveStudents`, `BannedStudents`,
+**List files:** `src/pages-v2/Campus/ActiveStudents`, `BannedStudents`,
 `DeactivatedStudents`, `DisengagedStudents` + `src/pages-v2/Campus/components/*` (StudentTable,
-StatsCard, etc.). **Modais de ação:** `src/components-v2/{BanUserModal, UnbanUserModal,
+StatsCard, etc.). **Action modals:** `src/components-v2/{BanUserModal, UnbanUserModal,
 DeactivateUserModal, ActivateUserModal, FlagUserModal, WriteNoteModal, SendPasswordResetModal,
 LogoutAllDevicesModal, StudentProfileModal}`.
 
-As listas seguem o mesmo padrão de `ActiveStudents.tsx`: `useQuery` com key incluindo
-`school/campus/página/busca/sort`, chamando `adminV2StudentsList({ status, page, limit, search,
-sortBy, sortOrder, schoolId, campusId })` + `adminV2StudentsStatsList`. Export condicionado a
+The lists follow the same pattern as `ActiveStudents.tsx`: `useQuery` with a key including
+`school/campus/page/search/sort`, calling `adminV2StudentsList({ status, page, limit, search,
+sortBy, sortOrder, schoolId, campusId })` + `adminV2StudentsStatsList`. Export is gated on
 `canExport(<resource>)`.
 
-### Ações e endpoints reais (verificado)
+### Actions and actual endpoints (verified)
 
-As mutations vivem nas tabelas em `src/pages-v2/Campus/components/` (`StudentTable.tsx`,
-`BannedStudentTable.tsx`, `DeactivatedStudentTable.tsx`), disparadas via `ActionDropdown`/modais e
-também a partir do `StudentProfileModal` (por callbacks `onBanUser/onDeactivateUser/onUnbanUser/onActivateUser`).
-Todas usam `useMutation` do React Query + toast + invalidação de `["students"]` (e `["studentStats"]`).
+The mutations live in the tables under `src/pages-v2/Campus/components/` (`StudentTable.tsx`,
+`BannedStudentTable.tsx`, `DeactivatedStudentTable.tsx`), triggered via `ActionDropdown`/modals and
+also from the `StudentProfileModal` (through the `onBanUser/onDeactivateUser/onUnbanUser/onActivateUser`
+callbacks). They all use React Query's `useMutation` + toast + invalidation of `["students"]`
+(and `["studentStats"]`).
 
-| Ação | `apiClient` | Endpoint | Payload | Invalida | Toast sucesso |
+| Action | `apiClient` | Endpoint | Payload | Invalidates | Success toast |
 |---|---|---|---|---|---|
-| **Ban** | `api.adminV2StudentsLockSettingsUpdate(id, …)` | `PUT /api/admin/v2/students/{id}/lock-settings` | `{ isLocked:true, lockReason, lockDuration }` (dias) | `students`, `studentStats` | "Student banned successfully" |
+| **Ban** | `api.adminV2StudentsLockSettingsUpdate(id, …)` | `PUT /api/admin/v2/students/{id}/lock-settings` | `{ isLocked:true, lockReason, lockDuration }` (days) | `students`, `studentStats` | "Student banned successfully" |
 | **Unban** | `api.adminV2StudentsUnbanCreate(id)` | `POST /api/admin/v2/students/{id}/unban` | — | `students`, `studentStats` | "User unbanned successfully" |
 | **Deactivate** | `api.adminV2StudentsDelete(id)` | `DELETE /api/admin/v2/students/{id}` | — | `students`, `studentStats` | "Student deactivated successfully" |
 | **Activate** | `api.adminV2StudentsActivateCreate(id)` | `POST /api/admin/v2/students/{id}/activate` | — | `students`, `studentStats` | "User activated successfully" |
 | **Flag** | `api.adminV2StudentsFlagCreate(id, { reason })` | `POST /api/admin/v2/students/{id}/flag` | `{ reason }` | `students` | "Student flagged successfully" |
 | **Unflag** | `api.adminV2StudentsUnflagCreate(id)` | `POST /api/admin/v2/students/{id}/unflag` | — | `students` | "Student unflagged successfully" |
 
-Mapeamento de duração do ban (`BanUserModal` → dias): 1/3/7/14/30/90 dias; "Permanent" → **36500**.
+Ban-duration mapping (`BanUserModal` → days): 1/3/7/14/30/90 days; "Permanent" → **36500**.
 
-> **Atenção (divergência de código):** existe `src/services/reportService.ts` com métodos
-> `banUserFromReport`, `getBannedUsers`, `unbanUser`, `getUserBanHistory`, `removeUser` que apontam
-> para endpoints **`adminReports*` / `adminUsersBanned*` / `adminUsers…Remove`** (rotas antigas). As
-> telas de estudante **não** usam esse service — elas chamam diretamente os endpoints
-> `adminV2Students*` da tabela acima. O `reportService` é usado no fluxo de reports (ver §9) e/ou é
-> legado. Documentado como **caminho alternativo/legado**.
+> **Caution (code divergence):** there is a `src/services/reportService.ts` with methods
+> `banUserFromReport`, `getBannedUsers`, `unbanUser`, `getUserBanHistory`, `removeUser` that point
+> to the **`adminReports*` / `adminUsersBanned*` / `adminUsers…Remove`** endpoints (old routes). The
+> student screens do **not** use this service — they call the `adminV2Students*` endpoints from the
+> table above directly. `reportService` is used in the reports flow (see §9) and/or is legacy.
+> Documented as an **alternative/legacy path**.
 
 ```mermaid
 sequenceDiagram
@@ -424,62 +426,62 @@ sequenceDiagram
     participant BE as walky-backend
     participant RQ as React Query
 
-    U->>Tbl: abre ações de um estudante
-    Tbl->>M: abre modal (ex. BanUserModal: duração+motivo+checkbox)
-    U->>M: confirma
+    U->>Tbl: opens actions for a student
+    Tbl->>M: opens modal (e.g., BanUserModal: duration+reason+checkbox)
+    U->>M: confirms
     M->>API: adminV2StudentsLockSettingsUpdate(id, {isLocked, lockReason, lockDuration})
     API->>BE: PUT /api/admin/v2/students/{id}/lock-settings
     BE-->>API: 200
     API->>RQ: invalidateQueries(["students"]) + ["studentStats"]
-    RQ->>BE: refetch da lista/stats
+    RQ->>BE: refetch the list/stats
     API->>U: toast "Student banned successfully"
 ```
 
-Regras de negócio (durações de ban, quem pode banir, notificação por email na deactivate, etc.):
-[business-rules.md §3](./business-rules.md#3-regras-de-moderação-e-gestão-de-estudantes).
+Business rules (ban durations, who can ban, email notification on deactivate, etc.):
+[business-rules.md §3](./business-rules.md#3-moderation-and-student-management-rules).
 
 ---
 
-## 9. Moderação de reports
+## 9. Report moderation
 
-**Arquivos:** `src/pages-v2/Moderation/{ReportSafety, ReportHistory}`,
+**Files:** `src/pages-v2/Moderation/{ReportSafety, ReportHistory}`,
 `src/components-v2/{ReportDetailModal, ReportDetailsModal, FlagModal, UnflagModal}`,
 `src/services/reportService.ts`.
 
-### Endpoints reais usados pela tela (verificado em `ReportSafety.tsx`)
+### Actual endpoints used by the screen (verified in `ReportSafety.tsx`)
 
-A tela `ReportSafety` usa **diretamente** os endpoints `adminV2Reports*` (via `useQuery`/`useMutation`),
-não o `reportService`. Filtros: `page`, `limit: 10`, `search`, `type` (Event/Idea/Space/Message/User,
+The `ReportSafety` screen uses the `adminV2Reports*` endpoints **directly** (via `useQuery`/`useMutation`),
+not `reportService`. Filters: `page`, `limit: 10`, `search`, `type` (Event/Idea/Space/Message/User,
 CSV), `status` (CSV), `sortBy: "reportDate"`, `sortOrder`, `schoolId`, `campusId`.
-**Status válidos (labels desta tela):** `Pending review | Under evaluation | Resolved | Dismissed`.
+**Valid statuses (labels on this screen):** `Pending review | Under evaluation | Resolved | Dismissed`.
 
-| Ação | `apiClient` | Endpoint |
+| Action | `apiClient` | Endpoint |
 |---|---|---|
-| Listar | `api.adminV2ReportsList(query)` | `GET /api/admin/v2/reports` |
+| List | `api.adminV2ReportsList(query)` | `GET /api/admin/v2/reports` |
 | Stats | `api.adminV2ReportsStatsList({schoolId,campusId})` | `GET /api/admin/v2/reports/stats` |
-| Detalhe | `api.adminV2ReportsDetail(id)` | `GET /api/admin/v2/reports/{id}` |
-| Mudar status | `api.adminV2ReportsStatusPartialUpdate(id, { status })` | `PATCH /api/admin/v2/reports/{id}/status` |
-| Adicionar nota | `api.adminV2ReportsNoteCreate(id, { note })` | `POST /api/admin/v2/reports/{id}/note` |
-| Flag do item denunciado | `api.adminV2{Students,Events,Ideas,Spaces}FlagCreate(id,{reason})` | `POST /api/admin/v2/{...}/{id}/flag` |
-| Unflag do item | `api.adminV2{Students,Events,Ideas,Spaces}UnflagCreate(id)` | `POST /api/admin/v2/{...}/{id}/unflag` |
-| Banir usuário do report | `api.adminV2StudentsLockSettingsUpdate(id,{isLocked,lockReason,lockDuration})` | `PUT /api/admin/v2/students/{id}/lock-settings` |
-| Desativar usuário do report | `api.adminV2StudentsDelete(id)` | `DELETE /api/admin/v2/students/{id}` |
+| Detail | `api.adminV2ReportsDetail(id)` | `GET /api/admin/v2/reports/{id}` |
+| Change status | `api.adminV2ReportsStatusPartialUpdate(id, { status })` | `PATCH /api/admin/v2/reports/{id}/status` |
+| Add note | `api.adminV2ReportsNoteCreate(id, { note })` | `POST /api/admin/v2/reports/{id}/note` |
+| Flag the reported item | `api.adminV2{Students,Events,Ideas,Spaces}FlagCreate(id,{reason})` | `POST /api/admin/v2/{...}/{id}/flag` |
+| Unflag the item | `api.adminV2{Students,Events,Ideas,Spaces}UnflagCreate(id)` | `POST /api/admin/v2/{...}/{id}/unflag` |
+| Ban the reported user | `api.adminV2StudentsLockSettingsUpdate(id,{isLocked,lockReason,lockDuration})` | `PUT /api/admin/v2/students/{id}/lock-settings` |
+| Deactivate the reported user | `api.adminV2StudentsDelete(id)` | `DELETE /api/admin/v2/students/{id}` |
 
-**Regra "nota obrigatória":** no `StatusDropdown`, mudar para **Resolved** ou **Dismissed** dispara
-`onNoteRequired` → abre `WriteNoteModal` (nota obrigatória, não-vazia, `maxCharacters` 500) →
-`adminV2ReportsNoteCreate` → **depois** `adminV2ReportsStatusPartialUpdate`. Outros status mudam
-direto. Invalidação: `["reports"]`, `["reportStats"]`, `["history-reports"]`, `["history-report-stats"]`.
+**"Mandatory note" rule:** in the `StatusDropdown`, changing to **Resolved** or **Dismissed** triggers
+`onNoteRequired` → opens `WriteNoteModal` (mandatory, non-empty note, `maxCharacters` 500) →
+`adminV2ReportsNoteCreate` → **then** `adminV2ReportsStatusPartialUpdate`. Other statuses change
+directly. Invalidation: `["reports"]`, `["reportStats"]`, `["history-reports"]`, `["history-report-stats"]`.
 
-> **Divergência:** `src/services/reportService.ts` expõe `getReports/updateReportStatus/
-> banUserFromReport/bulkUpdateReports` apontando para endpoints `adminReports*` (sem `v2`) com status
-> `pending|under_review|resolved|dismissed` e `bulk action: resolve|dismiss|under_review`. **A tela
-> `ReportSafety` não usa esse service** — usa `adminV2Reports*`. O `reportService` parece ser a
-> camada antiga; documentado em [business-rules.md §3](./business-rules.md#3-regras-de-moderação-e-gestão-de-estudantes)
-> como caminho legado.
+> **Divergence:** `src/services/reportService.ts` exposes `getReports/updateReportStatus/
+> banUserFromReport/bulkUpdateReports` pointing to `adminReports*` endpoints (without `v2`) with statuses
+> `pending|under_review|resolved|dismissed` and `bulk action: resolve|dismiss|under_review`. **The
+> `ReportSafety` screen does not use this service** — it uses `adminV2Reports*`. `reportService` appears
+> to be the old layer; documented in [business-rules.md §3](./business-rules.md#3-moderation-and-student-management-rules)
+> as a legacy path.
 
 ```mermaid
 sequenceDiagram
-    participant M as Moderador
+    participant M as Moderator
     participant RS as ReportSafety
     participant SD as StatusDropdown
     participant WM as WriteNoteModal
@@ -489,52 +491,52 @@ sequenceDiagram
     RS->>API: adminV2ReportsList({status, schoolId, campusId})
     API->>BE: GET /api/admin/v2/reports
     BE-->>RS: reports[] + stats
-    M->>SD: seleciona novo status
-    alt Resolved / Dismissed (nota obrigatória)
-        SD->>WM: onNoteRequired → abre modal
-        M->>WM: escreve nota
+    M->>SD: selects new status
+    alt Resolved / Dismissed (note required)
+        SD->>WM: onNoteRequired → opens modal
+        M->>WM: writes note
         WM->>API: adminV2ReportsNoteCreate(id, {note})
         WM->>API: adminV2ReportsStatusPartialUpdate(id, {status})
-    else outro status
+    else other status
         SD->>API: adminV2ReportsStatusPartialUpdate(id, {status})
     end
-    API->>RS: invalida ["reports"], ["reportStats"], history keys
+    API->>RS: invalidate ["reports"], ["reportStats"], history keys
 ```
 
-Ver [business-rules.md §3](./business-rules.md#3-regras-de-moderação-e-gestão-de-estudantes) e o
-controller do backend em [docs/admin/admin-reports-controller.md](./admin/admin-reports-controller.md).
+See [business-rules.md §3](./business-rules.md#3-moderation-and-student-management-rules) and the
+backend controller in [docs/admin/admin-reports-controller.md](./admin/admin-reports-controller.md).
 
 ---
 
-## 10. Gestão de campus e geofences
+## 10. Campus and geofence management
 
-**Arquivos:** `src/pages-v2/Admin/Campuses*`, `src/pages-v2/CampusBoundary/*`,
+**Files:** `src/pages-v2/Admin/Campuses*`, `src/pages-v2/CampusBoundary/*`,
 `src/services/campusService.ts`, `src/services/campusSyncService.ts`,
 `src/services/placeService.ts`.
 
-`campusService` (confirmado) faz o CRUD de campus (`campusesList/Create/Update/Delete`), mapeando
-`_id → id`. O geofence é o campo `coordinates` (`type: "Polygon"`, `coordinates: number[][][]`).
+`campusService` (confirmed) handles campus CRUD (`campusesList/Create/Update/Delete`), mapping
+`_id → id`. The geofence is the `coordinates` field (`type: "Polygon"`, `coordinates: number[][][]`).
 
-`campusSyncService` (confirmado) cuida da **sincronização de places** por boundary via Google Places:
+`campusSyncService` (confirmed) handles **place synchronization** by boundary via Google Places:
 - `syncCampus(id)` → `adminCampusSyncSyncCreate`
 - `syncAllCampuses()` → `adminCampusSyncSyncAllCreate`
 - `getSyncLogs(params)` → `adminCampusSyncLogsList`
 - `getCampusesWithSyncStatus()` → `adminCampusSyncCampusesList`
-- `previewCampusBoundary(id)` → `adminCampusSyncCampusPreviewList` (retorna bounds/center/area/search_points)
+- `previewCampusBoundary(id)` → `adminCampusSyncCampusPreviewList` (returns bounds/center/area/search_points)
 
-### Detalhes verificados
+### Verified details
 
-- **Listagem** (`src/pages-v2/Admin/Campuses/Campuses.tsx`): usa `api.adminV2CampusesList({ school_id })`,
-  paginação de 10, expande cada campus para ver a boundary num mapa read-only.
+- **Listing** (`src/pages-v2/Admin/Campuses/Campuses.tsx`): uses `api.adminV2CampusesList({ school_id })`,
+  pagination of 10, expands each campus to view its boundary on a read-only map.
 - **Geofence** (`src/pages-v2/CampusBoundary/CampusBoundary.tsx`): Google Maps (`@react-google-maps/api`,
-  libs `["places"]`). Desenho manual do polígono por cliques (mínimo **3** vértices); ao finalizar,
-  fecha o anel (repete o primeiro ponto) e gera GeoJSON `Polygon` com coords `[lng, lat]` (WGS84). O
-  polígono fica editável (arrastar vértices) e emite `onBoundaryChange`.
-  > **Nota de segurança:** a **chave do Google Maps está hardcoded** em `CampusBoundary.tsx`
-  > (`VITE_GOOGLE_MAPS_API_KEY` do `.env.example` **não** é usada). Confirma a nota de
+  libs `["places"]`). Manual polygon drawing by clicks (minimum **3** vertices); when finished, it
+  closes the ring (repeats the first point) and generates a GeoJSON `Polygon` with coords
+  `[lng, lat]` (WGS84). The polygon remains editable (drag vertices) and emits `onBoundaryChange`.
+  > **Security note:** the **Google Maps key is hardcoded** in `CampusBoundary.tsx`
+  > (`VITE_GOOGLE_MAPS_API_KEY` from `.env.example` is **not** used). This confirms the note in
   > [overview.md/integrations.md](./integrations.md).
-- **Sync de places:** `previewCampusBoundary(id)` mostra bounds/center/área/search_points antes;
-  `syncCampus(id)` executa e retorna `{ places_added, places_updated, places_removed, api_calls_used,
+- **Place sync:** `previewCampusBoundary(id)` shows bounds/center/area/search_points beforehand;
+  `syncCampus(id)` runs it and returns `{ places_added, places_updated, places_removed, api_calls_used,
   sync_status }`.
 
 ```mermaid
@@ -545,8 +547,8 @@ sequenceDiagram
     participant Maps as Google Maps
     participant BE as walky-backend
 
-    A->>CP: cria/edita campus (nome, endereço, timezone, polígono)
-    CP->>Maps: desenha geofence (Polygon)
+    A->>CP: creates/edits campus (name, address, timezone, polygon)
+    CP->>Maps: draws geofence (Polygon)
     CP->>CS: create/update({ campus_name, coordinates, … })
     CS->>BE: campusesCreate / campusesUpdate
     A->>CP: "Preview boundary"
@@ -558,28 +560,28 @@ sequenceDiagram
     BE-->>CP: { places_added, updated, removed, api_calls_used }
 ```
 
-Regras/validações de campus: [business-rules.md §6](./business-rules.md#6-regras-de-campus-geofences-e-ambassadors).
+Campus rules/validations: [business-rules.md §6](./business-rules.md#6-campus-geofence-and-ambassador-rules).
 
 ---
 
 ## 11. Ambassadors
 
-**Arquivos:** `src/pages-v2/Admin/Ambassadors*`, `src/services/ambassadorService.ts`,
+**Files:** `src/pages-v2/Admin/Ambassadors*`, `src/services/ambassadorService.ts`,
 `src/components-v2/{AddAmbassadorModal, DeleteAmbassadorModal}`.
 
-`ambassadorService` (confirmado) usa o cliente `apiClient.ambassadors.*` (router legado na raiz):
+`ambassadorService` (confirmed) uses the `apiClient.ambassadors.*` client (legacy router at the root):
 `ambassadorsList`, `ambassadorsDetail`, `ambassadorsCreate`, `ambassadorsUpdate`, `ambassadorsDelete`,
-`campusDetail(campusId)` (ambassadors por campus). `getAll` retorna `[]` em erro (fail-soft);
-`getById`/create/update/delete propagam o erro.
+`campusDetail(campusId)` (ambassadors by campus). `getAll` returns `[]` on error (fail-soft);
+`getById`/create/update/delete propagate the error.
 
-A tela `src/pages-v2/Admin/Ambassadors/Ambassadors.tsx` na prática usa endpoints v2
+The `src/pages-v2/Admin/Ambassadors/Ambassadors.tsx` screen actually uses v2 endpoints
 (`api.adminAmbassadorsList({ schoolId, campusId })`, `adminAmbassadorsCreate`, `adminAmbassadorsDelete`),
-enquanto o `ambassadorService` usa o router legado `apiClient.ambassadors.*`. O
-`AddAmbassadorModal` busca estudantes por nome exato via
+whereas `ambassadorService` uses the legacy `apiClient.ambassadors.*` router. The
+`AddAmbassadorModal` searches students by exact name via
 `api.adminV2MembersList({ search, role:"student", limit:20, exactMatch:true, schoolId, campusId })`
-e cria um ambassador por estudante selecionado com
-`{ name, email, user_id, school_id, campuses_id[] }`. Ações condicionadas a `canCreate("ambassadors")`
-e `canDelete("ambassadors")`.
+and creates one ambassador per selected student with
+`{ name, email, user_id, school_id, campuses_id[] }`. Actions are gated on `canCreate("ambassadors")`
+and `canDelete("ambassadors")`.
 
 ```mermaid
 sequenceDiagram
@@ -587,68 +589,68 @@ sequenceDiagram
     participant M as AddAmbassadorModal
     participant API as apiClient.api
     participant BE as walky-backend
-    A->>M: busca estudante por nome exato
+    A->>M: searches student by exact name
     M->>API: adminV2MembersList({search, role:"student", exactMatch:true})
     API->>BE: GET /api/admin/v2/members
-    A->>M: seleciona estudante(s) e confirma
+    A->>M: selects student(s) and confirms
     M->>API: adminAmbassadorsCreate({name, email, user_id, school_id, campuses_id})
     API->>BE: POST /api/ambassadors
-    API->>A: invalida lista de ambassadors
+    API->>A: invalidate ambassadors list
 ```
 
-Ver [business-rules.md §6](./business-rules.md#6-regras-de-campus-geofences-e-ambassadors).
+See [business-rules.md §6](./business-rules.md#6-campus-geofence-and-ambassador-rules).
 
 ---
 
 ## 12. Role Management / Administrator Settings / 2FA
 
-**Arquivos:** `src/pages-v2/Admin/{RoleManagement, AdministratorSettings}*`,
-`src/services/rolesService.ts`, `src/lib/permissions.ts` (hierarquia de atribuição),
+**Files:** `src/pages-v2/Admin/{RoleManagement, AdministratorSettings}*`,
+`src/services/rolesService.ts`, `src/lib/permissions.ts` (assignment hierarchy),
 `src/components-v2/{CreateMemberModal, ChangeRoleModal, RolePermissionsModal, LogoutAllDevicesModal}`.
-Endpoints de perfil (`src/API/Api.ts`): `adminV2SettingsPasswordUpdate`,
+Profile endpoints (`src/API/Api.ts`): `adminV2SettingsPasswordUpdate`,
 `adminProfile2FaEnableCreate` (`POST /api/admin/profile/2fa/enable`),
 `adminProfile2FaDisableCreate` (`POST /api/admin/profile/2fa/disable`),
 `adminProfileLogoutAllCreate` (`POST /api/admin/profile/logout-all`).
 
-`rolesService` (confirmado): `getRoles`, `getPermissions`, `getUserRoles`, `assignRole`,
+`rolesService` (confirmed): `getRoles`, `getPermissions`, `getUserRoles`, `assignRole`,
 `removeRole`, `checkPermission`, `createRole`, `updateRole`, `deleteRole`, `createPermission`,
 `deletePermission`.
 
-### Hierarquia de atribuição (de `permissions.ts → roleHierarchy`)
+### Assignment hierarchy (from `permissions.ts → roleHierarchy`)
 
-- `super_admin` pode atribuir: `school_admin`, `campus_admin`, `moderator`
-- `school_admin` pode atribuir: `campus_admin`, `moderator`
-- `campus_admin` pode atribuir: `moderator`
-- `moderator` / `walky_internal`: nada
+- `super_admin` can assign: `school_admin`, `campus_admin`, `moderator`
+- `school_admin` can assign: `campus_admin`, `moderator`
+- `campus_admin` can assign: `moderator`
+- `moderator` / `walky_internal`: nothing
 
 Helpers: `getAssignableRoles`, `getAssignableRoleDisplayNames`, `canAssignRole`,
 `canAssignRoleByDisplayName`.
 
-### AdministratorSettings (verificado) — 3 abas
+### AdministratorSettings (verified) — 3 tabs
 
 `src/pages-v2/Admin/AdministratorSettings/AdministratorSettings.tsx`.
 
-- **Personal Information:** `api.adminProfileList()` (carregar), `api.adminV2SettingsProfileUpdate({ firstName, lastName, position })`, avatar via `api.adminProfileAvatarCreate({ avatar: File })` (imagem, máx 5MB). Email/nome são read-only; só `position` é editável.
-- **Security:** trocar senha via `api.adminV2SettingsPasswordUpdate({ currentPassword, newPassword })` (nova senha mín. 8, confirmar igual); toggle **2FA** via `api.adminProfile2FaEnableCreate()` / `api.adminProfile2FaDisableCreate()`; logout de todos os dispositivos via `api.adminV2SettingsLogoutAllCreate()`.
-- **Danger Zone:** pedir exclusão de conta `api.adminV2SettingsDeleteAccountCreate({ reason })`, cancelar `…DeleteAccountCancelCreate`, status `…DeleteAccountStatusList`.
+- **Personal Information:** `api.adminProfileList()` (load), `api.adminV2SettingsProfileUpdate({ firstName, lastName, position })`, avatar via `api.adminProfileAvatarCreate({ avatar: File })` (image, max 5MB). Email/name are read-only; only `position` is editable.
+- **Security:** change password via `api.adminV2SettingsPasswordUpdate({ currentPassword, newPassword })` (new password min. 8, confirm matching); **2FA** toggle via `api.adminProfile2FaEnableCreate()` / `api.adminProfile2FaDisableCreate()`; log out of all devices via `api.adminV2SettingsLogoutAllCreate()`.
+- **Danger Zone:** request account deletion `api.adminV2SettingsDeleteAccountCreate({ reason })`, cancel `…DeleteAccountCancelCreate`, status `…DeleteAccountStatusList`.
 
-### RoleManagement (verificado)
+### RoleManagement (verified)
 
-`src/pages-v2/Admin/RoleManagement/RoleManagement.tsx` — lista membros via
+`src/pages-v2/Admin/RoleManagement/RoleManagement.tsx` — lists members via
 `api.adminV2MembersList({ page, limit, search, role, sortBy, sortOrder, schoolId, campusId })`.
-Criar (`adminV2MembersCreate({ name, email, role, title, school_id, campus_id })` — gera convite por
-email), mudar role (`adminV2MembersRolePartialUpdate(id, { role })`), remover
-(`adminV2MembersDelete(id)`), reset de senha (`adminV2MembersPasswordResetCreate(id)`), ativar/desativar
-(`adminV2MembersStatusPartialUpdate(id, { isActive })`). O dropdown de role no `CreateMemberModal`/
-`ChangeRoleModal` é filtrado por `getAssignableRoleDisplayNames(userRole)`. O `RolePermissionsModal`
-mostra a matriz read/create/update/delete/export/manage por recurso.
+Create (`adminV2MembersCreate({ name, email, role, title, school_id, campus_id })` — generates an
+email invite), change role (`adminV2MembersRolePartialUpdate(id, { role })`), remove
+(`adminV2MembersDelete(id)`), password reset (`adminV2MembersPasswordResetCreate(id)`), activate/deactivate
+(`adminV2MembersStatusPartialUpdate(id, { isActive })`). The role dropdown in `CreateMemberModal`/
+`ChangeRoleModal` is filtered by `getAssignableRoleDisplayNames(userRole)`. The `RolePermissionsModal`
+shows the read/create/update/delete/export/manage matrix by resource.
 
 ```mermaid
 flowchart TD
     subgraph Settings["AdministratorSettings"]
-        S1[Trocar senha] --> P1[adminV2SettingsPasswordUpdate]
-        S2[Ativar/Desativar 2FA] --> P2[adminProfile2FaEnable/Disable Create]
-        S3[Logout de todos os dispositivos] --> P3[adminProfileLogoutAllCreate]
+        S1[Change password] --> P1[adminV2SettingsPasswordUpdate]
+        S2[Enable/Disable 2FA] --> P2[adminProfile2FaEnable/Disable Create]
+        S3[Log out of all devices] --> P3[adminProfileLogoutAllCreate]
     end
     subgraph Roles["RoleManagement"]
         R1[getAssignableRoles user.role] --> R2[CreateMemberModal / ChangeRoleModal]
@@ -656,120 +658,121 @@ flowchart TD
     end
 ```
 
-Regras completas: [business-rules.md §5](./business-rules.md#5-regras-de-sessão-e-segurança) e
-[§1](./business-rules.md#1-matriz-de-permissões-por-role).
+Full rules: [business-rules.md §5](./business-rules.md#5-session-and-security-rules) and
+[§1](./business-rules.md#1-permission-matrix-by-role).
 
 ---
 
-## Fluxos técnicos transversais
+## Cross-cutting technical flows
 
-### T1. Camada Axios: interceptors, CSRF, token
+### T1. Axios layer: interceptors, CSRF, token
 
-**Arquivo:** `src/API/index.ts` (+ `src/API/http-client.ts` gerado, `src/API/WalkyAPI.ts`).
+**File:** `src/API/index.ts` (+ generated `src/API/http-client.ts`, `src/API/WalkyAPI.ts`).
 
-Há **duas** instâncias Axios com interceptors idênticos:
+There are **two** Axios instances with identical interceptors:
 1. `API` (default export) — `axios.create({ baseURL: VITE_API_BASE_URL ?? "http://localhost:8080/api", withCredentials: true })`.
-2. `apiClient` = `new Api(new HttpClient({ baseURL: baseURL.replace(/\/api\/?$/, "") }))` — o cliente
-   gerado por Swagger. O sufixo `/api` é **removido** do baseURL porque as rotas admin já incluem
-   `/api/...` e as legadas batem na raiz (`/ambassadors`, `/campus`, …). `withCredentials = true`.
+2. `apiClient` = `new Api(new HttpClient({ baseURL: baseURL.replace(/\/api\/?$/, "") }))` — the
+   Swagger-generated client. The `/api` suffix is **stripped** from the baseURL because the admin
+   routes already include `/api/...` and the legacy ones hit the root (`/ambassadors`, `/campus`, …).
+   `withCredentials = true`.
 
-**Request interceptor** (ambas as instâncias):
-- Injeta `Authorization: Bearer <token>` a partir do `localStorage.getItem("token")` (warn se ausente).
-- **CSRF em não-GET:** para métodos que não sejam `get/head/options`, procura o token CSRF em cookies
-  (`csrf_cookie_rr`, `XSRF-TOKEN`, `csrf_token`, `_csrf`, nessa ordem) e o envia em **dois** headers:
-  `X-CSRF-Token` e `X-XSRF-Token`.
+**Request interceptor** (both instances):
+- Injects `Authorization: Bearer <token>` from `localStorage.getItem("token")` (warns if missing).
+- **CSRF on non-GET:** for methods other than `get/head/options`, it looks for the CSRF token in
+  cookies (`csrf_cookie_rr`, `XSRF-TOKEN`, `csrf_token`, `_csrf`, in that order) and sends it in
+  **two** headers: `X-CSRF-Token` and `X-XSRF-Token`.
 
 ```mermaid
 flowchart TD
-    Req[Request sai] --> Tok{token no localStorage?}
-    Tok -- sim --> AddAuth[Authorization: Bearer token]
-    Tok -- não --> Warn[logger.warn]
-    AddAuth --> M{método é GET/HEAD/OPTIONS?}
+    Req[Request goes out] --> Tok{token in localStorage?}
+    Tok -- yes --> AddAuth[Authorization: Bearer token]
+    Tok -- no --> Warn[logger.warn]
+    AddAuth --> M{method is GET/HEAD/OPTIONS?}
     Warn --> M
-    M -- sim --> Send[envia]
-    M -- não --> Csrf{cookie CSRF encontrado?}
-    Csrf -- sim --> AddCsrf[X-CSRF-Token + X-XSRF-Token]
-    Csrf -- não --> Send
+    M -- yes --> Send[send]
+    M -- no --> Csrf{CSRF cookie found?}
+    Csrf -- yes --> AddCsrf[X-CSRF-Token + X-XSRF-Token]
+    Csrf -- no --> Send
     AddCsrf --> Send
 ```
 
-### T2. Tratamento de erro 401 / 403 (ACCOUNT_DEACTIVATED)
+### T2. Handling 401 / 403 errors (ACCOUNT_DEACTIVATED)
 
-**Arquivos:** `src/API/index.ts` (response interceptor), `src/contexts/DeactivatedUserContext.tsx`,
+**Files:** `src/API/index.ts` (response interceptor), `src/contexts/DeactivatedUserContext.tsx`,
 `src/components-v2/DeactivatedUserModal/DeactivatedUserModal.tsx`, `src/layout-v2/LayoutV2.tsx`.
 
-**Response interceptor** (ambas as instâncias):
-- **401:** remove `token` do `localStorage` e, se não estiver já em `/login`, faz
-  `window.location.href = "/login"`. (Não há tentativa de refresh.)
-- **403 com `code === "ACCOUNT_DEACTIVATED"` ou `"USER_DEACTIVATED"`:** chama `triggerDeactivatedModal()`.
-  Um 403 comum (permissão) **não** abre o modal.
+**Response interceptor** (both instances):
+- **401:** removes `token` from `localStorage` and, if not already on `/login`, does
+  `window.location.href = "/login"`. (No refresh attempt.)
+- **403 with `code === "ACCOUNT_DEACTIVATED"` or `"USER_DEACTIVATED"`:** calls `triggerDeactivatedModal()`.
+  An ordinary 403 (permission) does **not** open the modal.
 
-**Ponte fora do React:** `DeactivatedUserContext` expõe `registerDeactivatedSetter(setter)` e um
-`triggerDeactivatedModal()` global. `LayoutV2` registra o setter no mount. Assim o interceptor
-(código fora da árvore React) consegue acionar o modal. O botão "Log Out" do modal limpa `token`,
-`refreshToken`, `user` e vai para `/login`.
+**Bridge outside React:** `DeactivatedUserContext` exposes `registerDeactivatedSetter(setter)` and a
+global `triggerDeactivatedModal()`. `LayoutV2` registers the setter on mount. This lets the interceptor
+(code outside the React tree) trigger the modal. The modal's "Log Out" button clears `token`,
+`refreshToken`, `user` and goes to `/login`.
 
 ```mermaid
 sequenceDiagram
-    participant Any as Qualquer request
+    participant Any as Any request
     participant I as Axios response interceptor
     participant Ctx as DeactivatedUserContext (global setter)
-    participant Layout as LayoutV2 (registra setter)
+    participant Layout as LayoutV2 (registers setter)
     participant Modal as DeactivatedUserModal
 
-    Layout->>Ctx: registerDeactivatedSetter(setDeactivated)  (no mount)
-    Any->>I: resposta de erro
+    Layout->>Ctx: registerDeactivatedSetter(setDeactivated)  (on mount)
+    Any->>I: error response
     alt 401
         I->>I: remove token
         I->>Any: window.location.href="/login"
     else 403 code=ACCOUNT_DEACTIVATED/USER_DEACTIVATED
         I->>Ctx: triggerDeactivatedModal()
         Ctx->>Modal: isDeactivated = true
-        Modal->>Any: "Log Out" → limpa storage → /login
-    else 403 comum (permissão)
-        I->>Any: rejeita (sem modal)
+        Modal->>Any: "Log Out" → clear storage → /login
+    else ordinary 403 (permission)
+        I->>Any: reject (no modal)
     end
 ```
 
-### T3. Cache React Query (valores reais)
+### T3. React Query cache (actual values)
 
-**Arquivo:** `src/lib/queryClient.ts` (+ `main.tsx` que injeta o `QueryClientProvider`).
+**File:** `src/lib/queryClient.ts` (+ `main.tsx`, which injects the `QueryClientProvider`).
 
-Valores **reais** do `QueryClient`:
+**Actual** `QueryClient` values:
 
-| Opção | Valor | Efeito |
+| Option | Value | Effect |
 |---|---|---|
-| `queries.staleTime` | `1000 * 60 * 5` (**5 min**) | Dados considerados frescos por 5 min (sem refetch). |
-| `queries.gcTime` | `1000 * 60 * 10` (**10 min**) | Cache inativo é coletado após 10 min. |
-| `queries.retry` | função custom | **Não** re-tenta em 4xx (exceto **408**); senão até **3** tentativas. |
-| `queries.refetchOnWindowFocus` | `false` | Não refaz fetch ao focar a janela. |
-| `mutations.retry` | `1` | Mutations re-tentam 1 vez. |
+| `queries.staleTime` | `1000 * 60 * 5` (**5 min**) | Data considered fresh for 5 min (no refetch). |
+| `queries.gcTime` | `1000 * 60 * 10` (**10 min**) | Inactive cache is garbage-collected after 10 min. |
+| `queries.retry` | custom function | Does **not** retry on 4xx (except **408**); otherwise up to **3** attempts. |
+| `queries.refetchOnWindowFocus` | `false` | Does not refetch on window focus. |
+| `mutations.retry` | `1` | Mutations retry once. |
 
-Há uma `queryKeys` factory (`campuses`, `campus(id)`, `students`, `geofences(campusId)`,
-`ambassadors`, `ambassador(id)`, `ambassadorsByCampus(campusId)`), embora várias telas montem keys
-inline (ex.: `["students", page, search, status, sort, schoolId, campusId]`).
+There is a `queryKeys` factory (`campuses`, `campus(id)`, `students`, `geofences(campusId)`,
+`ambassadors`, `ambassador(id)`, `ambassadorsByCampus(campusId)`), although several screens build
+keys inline (e.g., `["students", page, search, status, sort, schoolId, campusId]`).
 
 ```mermaid
 flowchart LR
-    Q[useQuery key] --> C{no cache e fresco < 5min?}
-    C -- sim --> Hit[retorna cache, sem rede]
-    C -- não --> Fetch[queryFn → Axios]
-    Fetch -- erro 4xx exceto 408 --> NoRetry[não re-tenta]
-    Fetch -- erro 5xx/408/rede --> Retry[re-tenta até 3x]
-    Fetch -- ok --> Store[grava no cache, gcTime 10min]
+    Q[useQuery key] --> C{in cache and fresh < 5min?}
+    C -- yes --> Hit[return cache, no network]
+    C -- no --> Fetch[queryFn → Axios]
+    Fetch -- 4xx error except 408 --> NoRetry[no retry]
+    Fetch -- 5xx/408/network error --> Retry[retry up to 3x]
+    Fetch -- ok --> Store[write to cache, gcTime 10min]
 ```
 
 ---
 
 ## Cross-links
 
-- [business-rules.md](./business-rules.md) — regras de negócio extraídas do código (matriz RBAC,
-  sessão, moderação, campus/ambassadors, validações de forms).
-- [overview.md](./overview.md) — propósito, stack, público-alvo, env vars.
-- [integrations.md](./integrations.md) — integrações e camada de API.
-- [conventions.md](./conventions.md) — convenções de código.
+- [business-rules.md](./business-rules.md) — business rules extracted from the code (RBAC matrix,
+  session, moderation, campus/ambassadors, form validations).
+- [overview.md](./overview.md) — purpose, stack, audience, env vars.
+- [integrations.md](./integrations.md) — integrations and the API layer.
+- [conventions.md](./conventions.md) — code conventions.
 - [admin/admin-reports-controller.md](./admin/admin-reports-controller.md),
   [admin/admin-students-controller.md](./admin/admin-students-controller.md),
   [admin/admin-dashboard-controller.md](./admin/admin-dashboard-controller.md),
   [admin/admin-settings-controller.md](./admin/admin-settings-controller.md),
-  [admin/admin-ambassadors-controller.md](./admin/admin-ambassadors-controller.md) — contratos do backend.
+  [admin/admin-ambassadors-controller.md](./admin/admin-ambassadors-controller.md) — backend contracts.


### PR DESCRIPTION
## What this is

Adds complete technical documentation for the repository, generated from **direct code analysis**, plus `AI_CONTEXT.md` describing the Walky ecosystem (app, backend, admin, HQ) and how the 4 repos relate. All content is in **English**.

## Contents (`docs/`)

`README.md` (index) + 11 documents: `overview`, `architecture`, `folder-structure`, `workflows`, `business-rules`, `integrations`, `conventions`, `development`, `deployment`, `troubleshooting`, `ai-reference`. With Mermaid diagrams, a table of contents, and cross-links.

## Notes

- Documentation only — **no code changes**.
- The notes in `docs/README.md` capture real discrepancies found between docs/names and actual code behavior.
- Factual corrections from an internal docs review have been applied (accurate `.env` description, wired-vs-unused hooks, SAML/Husky notes, type counts, dead references, and fixed cross-file anchors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)